### PR TITLE
setup the repo for automated publication via echidna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+branches:
+  only:
+    - gh-pages
+
+env:
+  global:
+    - URL="http://w3c.github.io/html-aam/echidna-manifest"
+    - DECISION=""
+    - secure: "gaJ3u4lwQCD99LS+UQ4tTGWbbOPGnBm74qR+nmwnrBADgJPu7nU+QXk6Fvr3lQ+lX2+HvIu43MY4GU6lYKJOgjmjp0gGJx9cX7PD8dm9fMvZUNIL+1lBLQHQ5rQ8u1WAaaUhjDwk7EjYMDmQk3tGGB3Tc8gNe6+VrA+OmPLKJ8jjIz8FmrNxwBH16XcYDpPflMl2uZnXdmcjiWBZWejqUXthgZvSzTlBprZ022t4H4yKWpf8+s0zhrCiDlKYIVkzQB6pmF8CykbnH/3hHR0pv57NL4Ac6oaRtSe7Ggx+8EMUQJstUWpj+0L5ExLL5owarbjCluWQke/AdERr/XyHtziCc35G96cMvkpA4LjERJ2J6PyjvTTJQy1Cb/Ivc8f7jQ+mo9oHbfaof9wEIup4gahGfMlK+ZyYIn+TQDi2MlI56Wv0fxL/vp5wzN98Ha1Uu8FHkLM0nzdzed21xwo8Y7NTRTPpmueRbLzWpQTVIsW4d8YXBNWbDPNRNRtbMiByRoNvUpPUW4944JhHKbb/aKxKEogq6EGj5JQsWbmxseGYMeSReq0ECCk9diITGr4TnTitBH3hElQqVi12HY5FClXKdiL9PGQ9K0/UaJjVLjVvazTUfi7Pq8BgMbCD11P14Dn67MSF5J13h3yxc3VV/vJvK+FKw3A9z8HpY/+I1Ik="
+
+script:
+  - echo "ok"
+
+after_success:
+  - test $TRAVIS_PULL_REQUEST = false && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/echidna-manifest
+++ b/echidna-manifest
@@ -1,0 +1,2 @@
+index.html?specStatus=WD;shortName=html-aam-1.0 respec
+css/html-aam.css


### PR DESCRIPTION
@ylafon that PR should set up the repo for echidna.
Note, the decision url is missing from `.travis.yml` and the current `index.html` is not a complete respec document. As we discussed, [spec generator](https://labs.w3.org/spec-generator/?type=respec&url=https://w3c.github.io/html-aam/index.html?specStatus=WD;shortName=html-aam-1.0) should be able to produce a document that passes pubrules in order to use echidna