### PR TITLE
AX API: Complete mapping for 'time' element (Github issue #88)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3528,10 +3528,10 @@
                         <span class="type">AXRole: </span><code>AXGroup</code>
                     </div>
                     <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>?</code>
+                        <span class="type">AXSubrole: </span><code>AXTimeGroup</code>
                     </div>
                     <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>?</code>
+                        <span class="type">AXRoleDescription: </span><code>"group"</code>
                     </div>
                 </td>
                 <td class="comments"></td>
@@ -6598,6 +6598,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Platform Working Group (01-Oct-2016)</h4>
           <ul>
+	    <li>01-May-2017: Updated AX API mapping for <code>time</code> element. See <a href="https://github.com/w3c/html-aam/issues/88">GitHub issue #88</a>.</li>
             <li>27-Apr-2017: Updated UIA mappings for <code>lang</code> and <code>dir</code> attributes. See <a href="https://github.com/w3c/html-aam/issues/19">GitHub issue #19</a>.</li>
             <li>19-Apr-2017: Updated mapping for <code>colspan</code> and <code>rowspan</code> attributes. See GitHub <a href="https://github.com/w3c/html-aam/issues/56">issue #56</a> and <a href="https://github.com/w3c/html-aam/issues/57">issue #57</a>.</li>
             <li>03-Apr-2017: Updated mapping for <code>section</code> element. See <a href="https://github.com/w3c/html-aam/issues/79">GitHub issue #79</a>.</li>


### PR DESCRIPTION
* AXSubrole: AXTimeGroup
* AXRoleDescription: "group"

https://bugs.webkit.org/show_bug.cgi?id=171498