### PR TITLE
Move ValuePattern for a[href] from Core-AAM

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,13 @@
                 <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"><code>a</code></a> <span class="el-context">(represents a <a href="https://www.w3.org/TR/html/links.html#hyperlink">hyperlink</a>)</span></th>
                 <td class="aria"><a class="core-mapping" href="#role-map-link"><code>link</code></a> role </td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+                <td class="uia">
+                  <div class="general">Use WAI-ARIA mapping</div>
+                  <div>                    
+                    <span class="type">Control Pattern: </span><code>Value</code><br />
+                    <span class="type">Property:</span> Set <code>Value.Value</code> to the <code>href</code> attribute
+                  </div>
+                </td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="comments"></td>


### PR DESCRIPTION
Please see https://github.com/w3c/aria/pull/633

ARIA doesn't provide href attribute, so it makes sense to add it here