### PR TITLE
Remove left-over UIA Express mappings from State and Property Mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -4677,11 +4677,6 @@
                 <th><code>hidden</code></th>
                 <td class="elements"><a href="http://www.w3.org/TR/html51/editing.html#the-hidden-attribute" title="attr-hidden">HTML elements</a></td>
                 <td class="aria">&#160;</td>
-                <td class="uia-express">
-                  <div class="general">
-                    Excludes the element from being exposed in the <a>accessibility tree</a>.
-                  </div>                      
-                </td>
                 <td class="ia2">
                   <div class="general">
                     Excludes the element from being exposed in the <a>accessibility tree</a>.
@@ -4723,9 +4718,6 @@
                 <th><code>href</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-href"><code>a</code></a>; <a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-href"><code>area</code></a></td>
                 <td class="aria">&#160;</td>
-                <td class="uia-express">Creates a link accessible object. For details, refer to
-                    <a href="#el-a"><code>a</code></a> and <a href="#el-area"><code>area</code></a> element mappings. The value of the <code>href</code> attribute is stored in the <code>Value.Value</code> UIA property.
-                </td>
                 <td class="ia2">
                   <div class="general">
                     Creates a link accessible object. For details, refer to
@@ -4748,10 +4740,6 @@
                 <th><code>href</code></th>
                 <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-link-href"><code>link</code></a></td>
                 <td class="aria">&#160;</td>
-                <td class="uia-express">
-                  <div class="general">
-                    Not mapped
-                  </div></td>
                 <td class="ia2">
                   <div class="general">
                     Not mapped
@@ -5471,7 +5459,6 @@
                 <th><code>required</code></th>
                 <td class="elements"><a href="http://www.w3.org/TR/html51/semantics.html#attr-input-required"><code>input</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-select-required"><code>select</code></a>; <a href="http://www.w3.org/TR/html51/semantics.html#attr-textarea-required"><code>textarea</code></a></td>
                 <td class="aria"><a class="core-mapping" href="#ariaRequiredTrue"><code>aria-required</code></a></td>
-                <td class="uia-express"><p>Not mapped *</p>
               <p>* Exposed as <code>STATE_SYSTEM_ALERT_LOW</code>, <code>STATE_SYSTEM_ALERT_HIGH</code> in Firefox.</p></td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>


### PR DESCRIPTION
The HTML-AAM no longer includes mappings for UIA Express. In addition,
the presence of these left-over mappings in the State and Property
Mappings table results in broken mappings when viewing the content by
state/property.