### PR TITLE
Issue 106: The <form> element should only map to FORM landmark with restriction of accessible name 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1387,7 +1387,7 @@
             </tr>
             <tr tabindex="-1" id="el-form">
                 <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-form-element"><code>form</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-form "><code>form </code></a>role</td>
+                <td class="aria"><a class="core-mapping" href="#role-map-form "><code>form</code></a> role if the <a href="https://www.w3.org/TR/html5/forms.html#the-form-element"><code>form</code></a> element has an <a class="termref">accessible name</a>. Otherwise, no corresponding role.</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>

--- a/index.html
+++ b/index.html
@@ -1387,7 +1387,7 @@
             </tr>
             <tr tabindex="-1" id="el-form">
                 <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-form-element"><code>form</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-form "><code>form</code></a> role if the <a href="https://www.w3.org/TR/html5/forms.html#the-form-element"><code>form</code></a> element has an <a class="termref">accessible name</a>. Otherwise, no corresponding role.</td>
+                <td class="aria"><a class="core-mapping" href="#role-map-form "><code>form</code></a> role if the <a href="https://www.w3.org/TR/html/sec-forms.html#the-form-element"><code>form</code></a> element has an <a class="termref">accessible name</a>. Otherwise, no corresponding role.</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>


### PR DESCRIPTION
Updated the form element mapping to only be a form landmark when it html as an accessible name