### PR TITLE
Update mapping links

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
       tocIntroductory: true,
 
       ariaSpecURLs: {
-        "ED": "https://w3c.github.io/aria/aria/aria.html",
+        "ED": "http://w3c.github.io/aria/",
         "WD" : "https://www.w3.org/TR/wai-aria-1.1/",
         "FPWD" : "https://www.w3.org/TR/wai-aria-1.1/",
         "REC": "https://www.w3.org/TR/wai-aria/"

--- a/index.html
+++ b/index.html
@@ -61,24 +61,24 @@
       tocIntroductory: true,
 
       ariaSpecURLs: {
-        "ED": "http://w3c.github.io/aria/aria/aria.html",
-        "WD" : "http://www.w3.org/TR/wai-aria-1.1/",
-        "FPWD" : "http://www.w3.org/TR/wai-aria-1.1/",
-        "REC": "http://www.w3.org/TR/wai-aria/"
+        "ED": "https://w3c.github.io/aria/aria/aria.html",
+        "WD" : "https://www.w3.org/TR/wai-aria-1.1/",
+        "FPWD" : "https://www.w3.org/TR/wai-aria-1.1/",
+        "REC": "https://www.w3.org/TR/wai-aria/"
       },
 
       coreMappingURLs: {
-        "ED":   "http://w3c.github.io/aria/core-aam/core-aam.html",
-        "WD":   "http://www.w3.org/TR/core-aam-1.1/",
-        "FPWD": "http://www.w3.org/TR/core-aam-1.1/",
-        "REC":  "http://www.w3.org/TR/wai-aria-implementation/"
+        "ED":   "https://w3c.github.io/core-aam/",
+        "WD":   "https://www.w3.org/TR/core-aam-1.1/",
+        "FPWD": "https://www.w3.org/TR/core-aam-1.1/",
+        "REC":  "https://www.w3.org/TR/wai-aria-implementation/"
       },
 
       accNameURLs: {
-        "ED": "http://w3c.github.io/aria/accname-aam/accname-aam.html",
-        "WD" : "http://www.w3.org/TR/accname-aam-1.1/",
-        "FPWD": "http://www.w3.org/TR/accname-aam-1.1/",
-        "REC": "http://www.w3.org/TR/accname-aam/"
+        "ED": "https://w3c.github.io/accname/",
+        "WD" : "https://www.w3.org/TR/accname-aam-1.1/",
+        "FPWD": "https://www.w3.org/TR/accname-aam-1.1/",
+        "REC": "https://www.w3.org/TR/accname-aam/"
       },
 
       localBiblio: biblio,


### PR DESCRIPTION
This PR resolves [issue 112](https://github.com/w3c/html-aam/issues/112), updating the mapping URLs to the new editor's draft addresses.