### PR TITLE
UIA: Remove the limitation on accesskey mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -3503,7 +3503,7 @@
                 </td>
                 <td class="uia">
                   <div class="properties">
-                      If the value of the accesskey attribute is a single character, <code>AccessKey</code>.
+                      <span class="type">Properties: </span><code>AccessKey: &lt;value&gt;</code>
                   </div>
                 </td>
                 <td class="atk">


### PR DESCRIPTION
Per https://docs.microsoft.com/en-us/dotnet/api/system.windows.automation.automationelement.automationelementinformation.accesskey?view=netframework-4.7.1#System_Windows_Automation_AutomationElement_AutomationElementInformation_AccessKey the type of the property is a string and in my experiment accesskey="abc" got transparently mapped to preserve the value.