### PR TITLE
Correct ATK mapping for input type="color"

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
                 <td class="atk">
                   <div class="role">
                     <span class="type">Role: </span>
-                    <code>ATK_ROLE_PANEL</code>
+                    <code>ATK_ROLE_SECTION</code>
                   </div>
                   <div class="objattrs">
                     <span class="type">Object attributes: </span><code>xml-roles:address</code>


### PR DESCRIPTION
* If implemented as a textbox, it should be mapped as a textbox
* If implemented as a button, it should be mapped as a button

See github issue #139.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joanmarie/html-aam/pull/140.html" title="Last updated on Jan 31, 2019, 3:49 PM UTC (19741dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/140/c6ff7e9...joanmarie:19741dc.html" title="Last updated on Jan 31, 2019, 3:49 PM UTC (19741dc)">Diff</a>