### PR TITLE
fix refspec warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,13 +122,13 @@
   <section id="intro" class="informative">
     <h2>Introduction</h2>
     <p>This specification defines how HTML user agents must respond to and expose <a class="termref">role</a>, <a class="termref">state</a> and <a class="termref">property</a> information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default <cite><a href="https://www.w3.org/TR/wai-aria-1.1/">Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>) 1.1</a></cite> [[WAI-ARIA]] semantics must be exposed to the platform <a class="termref" data-lt="Accessibility API">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]] specification. In some cases, often due to features of the HTML host language or the accessibility API in question, an element or attribute's mapping differs from the corresponding ARIA mappings specified in the [[!CORE-AAM]]. Where an HTML element or attribute does not have any default WAI-ARIA semantics, the applicable mapping for each platform <a class="termref" data-lt="Accessibility API">accessibility API</a> is defined by this specification.</p>
-    <p>This document also adapts the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a> [[!ACCNAME-AAM]] for deriving the <a class="termref" data-lt="Accessible Name">accessible names</a> and <a class="termref" data-lt="Accessible Description">accessible descriptions</a> of HTML 5.1 [[HTML51]] elements, and provides accessible implementation examples for specific HTML 5.1 elements and features.</p>
+    <p>This document also adapts the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a> [[!ACCNAME-AAM]] for deriving the <a class="termref" data-lt="Accessible Name">accessible names</a> and <a class="termref" data-lt="Accessible Description">accessible descriptions</a> of HTML 5.2 [[HTML52]] elements, and provides accessible implementation examples for specific HTML 5.2 elements and features.</p>
     <p>Users often access HTML content using assistive technologies that rely on platform <a class="termref">accessibility <abbr title="Application Programming Interface">API</abbr></a> to obtain and interact with information from the page. This document is part of the following suite of accessibility API mapping specifications for content rendered by user agents: </p>
     <ul>
-       <li><cite><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a></cite> [[!ACCNAME-AAM]]</li>
-       <li><cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a></cite> [[!CORE-AAM]]</li>
-       <li><cite><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings</a></cite> [[HTML-AAM]]</li>
-       <li><cite><a href="https://www.w3.org/TR/svg-aam-1.0/">SVG Accessibility API Mappings</a></cite> [[SVG-AAM]]</li>
+      <li><cite><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a></cite> [[!ACCNAME-AAM]]</li>
+      <li><cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a></cite> [[!CORE-AAM]]</li>
+      <li><cite><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings</a></cite> [[HTML-AAM]]</li>
+      <li><cite><a href="https://www.w3.org/TR/svg-aam-1.0/">SVG Accessibility API Mappings</a></cite> [[SVG-AAM]]</li>
     </ul>
     <section id="intro_aapi">
       <h3>Accessibility APIs</h3>
@@ -157,11 +157,15 @@
     <h2>Mapping HTML to Accessibility APIs</h2>
     <section id="mapping_general">
       <h3>General Rules for Exposing WAI-ARIA Semantics</h3>
-      <p>WAI-ARIA support was first introduced to HTML in HTML5 [[!HTML5]]. Where an HTML element or attribute has default WAI-ARIA semantics, it <span class="rfc2119">MUST</span> be exposed to the platform <a class="termref" data-lt="Accessibility API">accessibility APIs</a> in a way that conforms to <a class="core-mapping" href="#mapping_general">General rules for exposing WAI-ARIA semantics</a> in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]].</p>
+      <p>
+        WAI-ARIA support was first introduced to HTML in HTML5 [[!HTML5]]. Where an HTML element or attribute has default WAI-ARIA semantics, it <span class="rfc2119">MUST</span> be exposed to the platform <a class="termref" data-lt="Accessibility API">accessibility APIs</a> in a way that conforms to <a class="core-mapping" href="#mapping_general">General rules for exposing WAI-ARIA semantics</a> in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]].
+      </p>
     </section>
     <section id="mapping_conflicts">
       <h3>Conflicts Between Native Markup Semantics and WAI-ARIA</h3>
-      <p>Where the host language is HTML 5.1 [[!HTML51]], user agents <span class="rfc2119">MUST</span> conform to <a class="core-mapping" href="#mapping_conflicts">Conflicts between native markup semantics and WAI-ARIA</a> in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]]. </p>
+      <p>
+        Where the host language is HTML 5.2 [[!HTML52]], user agents <span class="rfc2119">MUST</span> conform to <a class="core-mapping" href="#mapping_conflicts">Conflicts between native markup semantics and WAI-ARIA</a> in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]].
+      </p>
     </section>
     <section id="mapping_nodirect">
       <h3>Exposing HTML Features That Do Not Directly Map to Accessibility APIs</h3>
@@ -850,7 +854,7 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-command-command">
-                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html51/semantics.html#commands">defines a command</a>, whose <a href="https://www.w3.org/TR/html51/semantics.html#command-facet-type">Type</a> facet is "command", and that is a descendant of a <a href="https://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html51/semantics.html#toolbar-state">toolbar</a> state</span></th>
+                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html52/semantics.html#commands">defines a command</a>, whose <a href="https://www.w3.org/TR/html52/semantics.html#command-facet-type">Type</a> facet is "command", and that is a descendant of a <a href="https://www.w3.org/TR/html52/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html52/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html52/semantics.html#toolbar-state">toolbar</a> state</span></th>
                 <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role </td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -859,8 +863,8 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-command-radio">
-                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html51/semantics.html#commands">defines a command</a>, whose <a href="https://www.w3.org/TR/html51/semantics.html#command-facet-type">Type</a> facet is "radio", and that is a descendant of a <a href="https://www.w3.org/TR/html51/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html51/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html51/semantics.html#toolbar-state">toolbar</a> state</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the command's <a href="https://www.w3.org/TR/html51/semantics.html#command-facet-checkedstate">Checked State</a> facet is true, and "false" otherwise </td>
+                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html52/semantics.html#commands">defines a command</a>, whose <a href="https://www.w3.org/TR/html52/semantics.html#command-facet-type">Type</a> facet is "radio", and that is a descendant of a <a href="https://www.w3.org/TR/html52/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html52/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html52/semantics.html#toolbar-state">toolbar</a> state</span></th>
+                <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the command's <a href="https://www.w3.org/TR/html52/semantics.html#command-facet-checkedstate">Checked State</a> facet is true, and "false" otherwise </td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -5020,7 +5024,7 @@
             </tr>
             <!-- <tr tabindex="-1" id="att-55">
                 <th><code>summary</code></th>
-                <td><a href="https://www.w3.org/TR/html51/obsolete.html#attr-table-summary"><code>table</code></a></td>
+                <td><a href="https://www.w3.org/TR/html52/obsolete.html#attr-table-summary"><code>table</code></a></td>
                 <td>Yes</td>
                 <td>Yes</td>
                 <td></td>

--- a/index.html
+++ b/index.html
@@ -121,8 +121,8 @@
   </section>
   <section id="intro" class="informative">
     <h2>Introduction</h2>
-    <p>This specification defines how HTML user agents must respond to and expose <a class="termref">role</a>, <a class="termref">state</a> and <a class="termref">property</a> information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default <cite><a href="https://www.w3.org/TR/wai-aria-1.1/">Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>) 1.1</a></cite> [[!WAI-ARIA]] semantics must be exposed to the platform <a class="termref" data-lt="Accessibility API">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]] specification. In some cases, often due to features of the HTML host language or the accessibility API in question, an element or attribute's mapping differs from the corresponding ARIA mappings specified in the [[!CORE-AAM]]. Where an HTML element or attribute does not have any default WAI-ARIA semantics, the applicable mapping for each platform <a class="termref" data-lt="Accessibility API">accessibility API</a> is defined by this specification.</p>
-    <p>This document also adapts the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a> [[!ACCNAME-AAM]] for deriving the <a class="termref" data-lt="Accessible Name">accessible names</a> and <a class="termref" data-lt="Accessible Description">accessible descriptions</a> of HTML 5.1 [[!HTML51]] elements, and provides accessible implementation examples for specific HTML 5.1 elements and features.</p>
+    <p>This specification defines how HTML user agents must respond to and expose <a class="termref">role</a>, <a class="termref">state</a> and <a class="termref">property</a> information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default <cite><a href="https://www.w3.org/TR/wai-aria-1.1/">Accessible Rich Internet Applications (<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>) 1.1</a></cite> [[WAI-ARIA]] semantics must be exposed to the platform <a class="termref" data-lt="Accessibility API">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the <a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a> [[!CORE-AAM]] specification. In some cases, often due to features of the HTML host language or the accessibility API in question, an element or attribute's mapping differs from the corresponding ARIA mappings specified in the [[!CORE-AAM]]. Where an HTML element or attribute does not have any default WAI-ARIA semantics, the applicable mapping for each platform <a class="termref" data-lt="Accessibility API">accessibility API</a> is defined by this specification.</p>
+    <p>This document also adapts the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a> [[!ACCNAME-AAM]] for deriving the <a class="termref" data-lt="Accessible Name">accessible names</a> and <a class="termref" data-lt="Accessible Description">accessible descriptions</a> of HTML 5.1 [[HTML51]] elements, and provides accessible implementation examples for specific HTML 5.1 elements and features.</p>
     <p>Users often access HTML content using assistive technologies that rely on platform <a class="termref">accessibility <abbr title="Application Programming Interface">API</abbr></a> to obtain and interact with information from the page. This document is part of the following suite of accessibility API mapping specifications for content rendered by user agents: </p>
     <ul>
        <li><cite><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings</a></cite> [[!ACCNAME-AAM]]</li>
@@ -144,7 +144,7 @@
     </section>
   </section>
   <section id="conformance">
-    <p>These <a class="bibref" href="#bib-RFC2119">RFC2119</a> key words are formatted in uppercase and contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When these key words are used, but do not share this format, they do not convey any formal conformance requirements in the RFC2119 sense, and are merely explanatory, i.e., informative. As much as possible, such usage is avoided in this specification.</p>
+    <p>These <a class="bibref" href="#bib-rfc2119">RFC2119</a> key words are formatted in uppercase and contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When these key words are used, but do not share this format, they do not convey any formal conformance requirements in the RFC2119 sense, and are merely explanatory, i.e., informative. As much as possible, such usage is avoided in this specification.</p>
     <p>The classification of a section as normative or non-normative applies to the entire section and all sub-sections of that section.</p>
     <p>Normative sections provide requirements that authors, user agents, and assistive technologies MUST follow for an implementation to conform to this specification.</p>
     <p>Non-normative sections provide information useful to understanding the specification. Such sections may contain examples of recommended practice, but it is not required to follow such recommendations in order to conform to this specification.</p>
@@ -1202,15 +1202,26 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-figure">
-                <th><a href="https://www.w3.org/TR/html/grouping-content.html#the-figure-element"><code>figure</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-figure"><code>figure</code></a> role</td>
+                <th>
+                  <a href="https://www.w3.org/TR/html/grouping-content.html#the-figure-element"><code>figure</code></a>
+                </th>
+                <td class="aria">
+                  <a class="core-mapping" href="#role-map-figure"><code>figure</code></a> role
+                </td>
                 <td class="ia2">
                   <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
                   <div class="relations">
                     <span class="type">Relations: </span><code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-figcaption"><code>figcaption</code></a> element
                   </div>
                 </td>
-                <td class="uia"><div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping                  </div>                  <div class="general">Accessible name derived from <code>figcaption</code> according to the <a href="#h-figure-element-accessible-name-computation"><code>figure</code> Element Accessible Name Computation</a></div>
+                <td class="uia">
+                  <div class="role">
+                    <span class="type">Role:</span>
+                    Use WAI-ARIA mapping
+                  </div>
+                  <div class="general">
+                    Accessible name derived from <code>figcaption</code> according to the <a href="#figure-element-accessible-name-computation"><code>figure</code> Element Accessible Name Computation</a>
+                  </div>
               </td>
                 <td class="atk">
                   <div class="role">
@@ -1224,9 +1235,11 @@
                     <code>ATK_RELATION_LABELLED_BY</code> with child <a href="#el-figcaption"><code>figcaption</code></a> element
                   </div>
                 </td>
-              <td class="ax"><div class="role"><span class="type">AXRole: </span>Use WAI-ARIA mapping</div>
-                  <div class="subrole"></div></td>
-                <td class="comments"></td>
+              <td class="ax">
+                <div class="role"><span class="type">AXRole: </span>Use WAI-ARIA mapping</div>
+                <div class="subrole"></div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-footer-ancestorbody">
                 <th><a href="https://www.w3.org/TR/html/sections.html#the-footer-element"><code>footer</code></a> (scoped to the <a href="https://www.w3.org/TR/html/sections.html#the-body-element"><code>body</code></a> element)</th>


### PR DESCRIPTION
closes #154

fixes broken instances of wai-aria and html 5.1 links.
fixes links for in-page linking to figure acc name computation for figure
fixes link for RFC2119 (capitalization error)

Not fixed:
under the Important Terms section, a link for “Deprecated Requirements” was not fixed due to it being imported from: https://rawgit.com/w3c/aria/master/common/terms.html