### PR TITLE
Add macOS mappings for the meter element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2393,7 +2393,15 @@
                   <div class="properties"><span class="type">Properties: </span><code>AtkRange</code></div>
                 </td>
                 <td class="ax">
-                    <div class="general">?</div>
+                    <div class="role">
+                        <span class="type">AXRole: </span><code>AXLevelIndicator</code>
+                    </div>
+                    <div class="subrole">
+                        <span class="type">AXSubrole: </span><code>(nil)</code>
+                    </div>
+                    <div class="roledesc">
+                        <span class="type">AXRoleDescription: </span><code>"level indicator"</code>
+                    </div>
                 </td>
                 <td class="comments">See <a href="https://github.com/w3c/html-aam/issues/2">GitHub issue #2</a>.</td>
             </tr>


### PR DESCRIPTION
As seen in https://trac.webkit.org/changeset/241989/webkit, the expected
mappings for AXAPI for the meter element are:

AXRole: AXLevelIndicator
AXSubrole: (nil)
AXRoleDescription: "level indicator"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joanmarie/html-aam/pull/169.html" title="Last updated on Feb 25, 2019, 12:56 PM UTC (3cc3d96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/169/85673ea...joanmarie:3cc3d96.html" title="Last updated on Feb 25, 2019, 12:56 PM UTC (3cc3d96)">Diff</a>