### PR TITLE
Update address mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,18 +341,23 @@
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
                   <div class="role">
-                    <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
+                    <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
+                  </div>
+                  <div class="ifaces">
+                    <span class="type">Interfaces: </span>
+                    <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
                   </div>
                 </td>
                 <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Group</code>
-                    </div>
+                  <div class="ctrltype"><span class="type">Control Type: </span><code>Group</code></div>
                 </td>
                 <td class="atk">
                   <div class="role">
                     <span class="type">Role: </span>
                     <code>ATK_ROLE_SECTION</code>
+                  </div>
+                   <div class="ifaces">
+                    <span class="type">Interfaces: </span><code>AtkText</code>; <code>AtkHypertext</code>
                   </div>
                 </td>
                 <td class="ax">
@@ -361,6 +366,9 @@
                     </div>
                     <div class="subrole">
                         <span class="type">AXSubrole: </span><code>(nil)</code>
+                    </div>
+                    <div class="roledesc">
+                        <span class="type">AXRoleDescription: </span><code>"group"</code>
                     </div>
                 </td>
                 <td class="comments"></td>
@@ -976,7 +984,7 @@
                 <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="comments"></td>
             </tr>
-           <tr tabindex="-1" id="el-div">
+            <tr tabindex="-1" id="el-div">
                 <th><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><code>div</code></a></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">

--- a/index.html
+++ b/index.html
@@ -343,25 +343,16 @@
                   <div class="role">
                     <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
                   </div>
-                  <div class="objattrs">
-                    <span class="type">Object attributes: </span><code>xml-roles:address</code>
-                  </div>
                 </td>
                 <td class="uia">
                     <div class="ctrltype">
                         <span class="type">Control Type: </span><code>Group</code>
-                    </div>
-                    <div class="ctrltype">
-                      <span class="type">Localized Control Type: </span><code>"address"</code>
                     </div>
                 </td>
                 <td class="atk">
                   <div class="role">
                     <span class="type">Role: </span>
                     <code>ATK_ROLE_SECTION</code>
-                  </div>
-                  <div class="objattrs">
-                    <span class="type">Object attributes: </span><code>xml-roles:address</code>
                   </div>
                 </td>
                 <td class="ax">
@@ -370,9 +361,6 @@
                     </div>
                     <div class="subrole">
                         <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"address"</code>
                     </div>
                 </td>
                 <td class="comments"></td>
@@ -5858,7 +5846,7 @@
             If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>
-            If the <a class="termref">accessible description</a> is still empty, then:, if the <code>table</code> element has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> that is a <code>caption</code> element and  it wasn't used as the <a class="termref">accessible name</a>, then use the subtree of the first such element.
+            If the <a class="termref">accessible description</a> is still empty, then:, if the <code>table</code> element has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> that is a <code>caption</code> element and it wasn't used as the <a class="termref">accessible name</a>, then use the subtree of the first such element.
           </li>
           <li>
             If the <a class="termref">accessible description</a> is still empty, then: if the <code>table</code> element has a <code>title</code> attribute and it wasn't used as the <a class="termref">accessible name</a>, then use that attribute.
@@ -5902,7 +5890,7 @@
         <h4><code>a</code> Element Accessible Name Computation</h4>
         <ol>
           <li>
-           If the <code>a</code> element  has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+           If the <code>a</code> element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>Otherwise use <code>a</code> element subtree.</li>
           <li>Otherwise use the <code>title</code> attribute.</li>


### PR DESCRIPTION
Closes #170 and closes #166 

These changes essentially remove any special mappings that were specified for the `address` element, instead exposing it more like a `div`.

@joanmarie and @stevefaulkner, please verify these changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/171.html" title="Last updated on Feb 26, 2019, 9:07 PM UTC (7841f7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/171/3599397...7841f7a.html" title="Last updated on Feb 26, 2019, 9:07 PM UTC (7841f7a)">Diff</a>