### PR TITLE
Add current UIA mappings for meter

### DIFF
--- a/index.html
+++ b/index.html
@@ -2376,7 +2376,15 @@
                   </div>
                 </td>
                 <td class="uia">
-                    <div class="general">?</div>
+                  <div class="ctrltype">
+                    <span class="type">Control Type: </span><code>ProgressBar</code>
+                  </div>
+                  <div class="ctrltype">
+                    <span class="type">Localized Control Type: </span><code>meter</code>
+                  </div>
+                  <div class="ctrlpattern">
+                    <span class="type">Control Pattern: </span><code>RangeValue</code>
+                  </div>
                 </td>
                 <td class="atk">
                   <div class="role">


### PR DESCRIPTION
Filling in UIA info for `<meter>` mappings, for issue #2


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/melanierichards/html-aam/pull/172.html" title="Last updated on Feb 28, 2019, 1:45 AM UTC (61ec235)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/172/2452bd8...melanierichards:61ec235.html" title="Last updated on Feb 28, 2019, 1:45 AM UTC (61ec235)">Diff</a>