### PR TITLE
Update mappings for sub and sup for IA2

### DIFF
--- a/index.html
+++ b/index.html
@@ -3029,7 +3029,9 @@
                 <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sub</code></a></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
-                  <div class="general">No accessible object.</div>
+                  <div class="role">
+                    <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
+                  </div>
                   <div class="properties">
                     <span class="type">Text attributes: </span><code>text-position:sub</code> on the text container
                   </div>
@@ -3102,7 +3104,9 @@
                 <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sup</code></a></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
-                  <div class="general">No accessible object.</div>
+                  <div class="role">
+                    <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
+                  </div>
                   <div class="properties">
                     <span class="type">Text attributes: </span><code>text-position:super</code> on the text container
                   </div>

--- a/index.html
+++ b/index.html
@@ -6059,6 +6059,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Platform Working Group (01-Oct-2016)</h4>
           <ul>
+            <li>20-Mar-2019: Updated IA2 mappings for <code>sup</code> and <code>sub</code> elements. See <a href="https://github.com/w3c/html-aam/issues/174">GitHub issue #174</a>.</li>
             <li>26-Feb-2019: Updated mappings for the <code>address</code> element. See <a href="https://github.com/w3c/html-aam/issues/170">GitHub issue #170</a>.</li>
             <li>19-Feb-2019: Added <code>placeholder</code> attribute to accessible name computation for various <code>input</code> elements. See <a href="https://github.com/w3c/html-aam/issues/167">GitHub issue #167</a>.</li>
             <li>07-Feb-2018: Added entries for the <code>rb</code> and <code>rtc</code> elements, and updated AXAPI mappings for the <code>rb</code>, <code>rt</code> and <code>ruby</code> elements. See <a href="https://github.com/w3c/html-aam/issues/115">GitHub issue #115</a>.</li>

--- a/index.html
+++ b/index.html
@@ -3033,7 +3033,7 @@
                     <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
                   </div>
                   <div class="properties">
-                    <span class="type">Text attributes: </span><code>text-position:sub</code> on the text container
+                    <span class="type">Text attributes: </span><code>text-position:sub</code>
                   </div>
                 </td>
                 <td class="uia">
@@ -3108,7 +3108,7 @@
                     <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_TEXT_FRAME</code>
                   </div>
                   <div class="properties">
-                    <span class="type">Text attributes: </span><code>text-position:super</code> on the text container
+                    <span class="type">Text attributes: </span><code>text-position:super</code>
                   </div>
                 </td>
                 <td class="uia">


### PR DESCRIPTION
Change the mapping from "No accessible object" to ROLE_SYSTEM_TEXT for
MSAA and IA2_ROLE_TEXT_FRAME for IAccessible2.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joanmarie/html-aam/pull/175.html" title="Last updated on Mar 19, 2019, 4:42 PM UTC (2aa4c2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/175/34c1a04...joanmarie:2aa4c2c.html" title="Last updated on Mar 19, 2019, 4:42 PM UTC (2aa4c2c)">Diff</a>