### PR TITLE
Update UIA mappings for sub and sup elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3037,7 +3037,10 @@
                   </div>
                 </td>
                 <td class="uia">
-                  <div class="general">No accessible object. Exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
+                  <div class="ctrltype">
+                      <span class="type">Control Type: </span><code>Text</code>
+                  </div>
+                  <div class="general">Styles used are exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.
                   </div>
                 </td>
                 <td class="atk">
@@ -3112,7 +3115,10 @@
                   </div>
                 </td>
                 <td class="uia">
-                  <div class="general">No accessible object. Exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
+                  <div class="ctrltype">
+                      <span class="type">Control Type: </span><code>Text</code>
+                  </div>
+                  <div class="general">Styles used are exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.
                   </div>
                 </td>
                 <td class="atk">


### PR DESCRIPTION
`sub` and `sup` elements actually should generate controls in the accessibility tree in UIA; updating HTML-AAM to match reality.

I'm reviewing the other phrasing content elements for els that should likewise generate controls (and aren't currently specced that way), so I expect I'll have a followup PR. But thought I'd contribute just this for now to unblock [Core-AAM #43](https://github.com/w3c/core-aam/issues/43)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/melanierichards/html-aam/pull/177.html" title="Last updated on Apr 4, 2019, 12:51 AM UTC (0759531)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/177/885465b...melanierichards:0759531.html" title="Last updated on Apr 4, 2019, 12:51 AM UTC (0759531)">Diff</a>