### PR TITLE
clarify hidden mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <title>HTML Accessibility API Mappings 1.0</title>
   <meta charset="utf-8" />
+  <title>HTML Accessibility API Mappings 1.0</title>
   <!-- Temporary replacement of these 2 links to CSS resources at rawgit.com with local sources until common solution for resources like these shared among different AAMs is found (note two arrow images added to local img/ dir referenced from mapping-tables.css)-->
   <!--
   <link href="https://rawgit.com/w3c/aria/master/common/css/mapping-tables.css" rel="stylesheet" />
@@ -4191,7 +4191,7 @@
             <tr tabindex="-1" id="att-hidden">
                 <th><code>hidden</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#the-hidden-attribute">HTML elements</a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaHiddenTrue"><code>aria-hidden</code></a>="true"</td>
+                <td class="aria"><a class="core-mapping" href="#ariaHiddenTrue"><code>aria-hidden</code></a>="true" if the element is <code>display: none</code>, or if the element is <code>visibility: hidden</code>. If the element is no longer <code>display: none</code> or <code>visibility: hidden</code> then it does not map.</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>


### PR DESCRIPTION
note that the `hidden` attribute only maps to `aria-hidden=true` as long as it continues to be `display: none` or `visibility: hidden`.  otherwise it does not map.

Closes #178 