### PR TITLE
remove value from input type=image AccName comp.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5609,7 +5609,7 @@
             If the control has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>Otherwise use <code>alt</code> attribute.</li>
-          <li>Otherwise use <code>value</code> attribute.</li>
+          <!-- <li>Otherwise use <code>value</code> attribute.</li> -->
           <li>Otherwise use <code>title</code> attribute.</li>
           <li>
             Otherwise the user agent may provide an <a class="termref">accessible name</a> via a localized string of the phrase &quot;Submit Query&quot;.


### PR DESCRIPTION
closes #181

`value` is not a valid attribute for `input type=“image”` so it should be removed from the accessible name computation.