### PR TITLE
176 map and area updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -5866,7 +5866,7 @@
         <h4><code>img</code> Element Accessible Name Computation</h4>
         <ol>
           <li>
-            If the <code>img</code> element  has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the <code>img</code> element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>Otherwise use <code>alt</code> attribute.</li>
           <li>Otherwise use <code>title</code> attribute.</li>
@@ -5970,6 +5970,36 @@
       </section>
       <section>
         <h4><code>a</code> Element Accessible Description Computation</h4>
+        <ol>
+          <li>
+            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+          </li>
+          <li>
+            Otherwise use the <code>title</code> attribute if it wasn't used as the <a class="termref">accessible name</a>.
+          </li>
+          <li>
+            If none of the above yield a usable text string there is no <a class="termref">accessible description</a>.
+          </li>
+        </ol>
+      </section>
+    </section>
+    <section>
+      <h3><code>area</code> Element</h3>
+      <section>
+        <h4><code>area</code> Element Accessible Name Computation</h4>
+        <ol>
+          <li>
+           If the <code>area</code> element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+          </li>
+          <li>Otherwise use <code>area</code> element's <code>alt</code> attribute.</li>
+          <li>Otherwise use the <code>title</code> attribute.</li>
+          <li>
+            If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h4><code>area</code> Element Accessible Description Computation</h4>
         <ol>
           <li>
             If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
@@ -6108,6 +6138,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Platform Working Group (01-Oct-2016)</h4>
           <ul>
+            <li>16-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">Pull request #177</a>.</li>
             <li>11-Apr-2019: Update UIA mappings for <code>sub</code> and <code>sup</code> elements. See <a href="https://github.com/w3c/html-aam/pull/177">Pull request #177</a>.</li>
             <li>20-Mar-2019: Updated IA2 mappings for <code>sup</code> and <code>sub</code> elements. See <a href="https://github.com/w3c/html-aam/issues/174">GitHub issue #174</a>.</li>
             <li>26-Feb-2019: Updated mappings for the <code>address</code> element. See <a href="https://github.com/w3c/html-aam/issues/170">GitHub issue #170</a>.</li>

--- a/index.html
+++ b/index.html
@@ -6138,7 +6138,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Platform Working Group (01-Oct-2016)</h4>
           <ul>
-            <li>16-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">Pull request #177</a>.</li>
+            <li>21-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">GitHub issue #176</a>.</li>
             <li>11-Apr-2019: Update UIA mappings for <code>sub</code> and <code>sup</code> elements. See <a href="https://github.com/w3c/html-aam/pull/177">Pull request #177</a>.</li>
             <li>20-Mar-2019: Updated IA2 mappings for <code>sup</code> and <code>sub</code> elements. See <a href="https://github.com/w3c/html-aam/issues/174">GitHub issue #174</a>.</li>
             <li>26-Feb-2019: Updated mappings for the <code>address</code> element. See <a href="https://github.com/w3c/html-aam/issues/170">GitHub issue #170</a>.</li>

--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>HTML Accessibility API Mappings 1.0</title>
   <!-- Temporary replacement of these 2 links to CSS resources at rawgit.com with local sources until common solution for resources like these shared among different AAMs is found (note two arrow images added to local img/ dir referenced from mapping-tables.css)-->
   <!--
-  <link href="https://rawgit.com/w3c/aria/master/common/css/mapping-tables.css" rel="stylesheet" />
-  <link href="https://rawgit.com/w3c/aria/master/common/css/common.css" rel="stylesheet" />
+  <link href="https://rawgit.com/w3c/aria/master/common/css/mapping-tables.css" rel="stylesheet">
+  <link href="https://rawgit.com/w3c/aria/master/common/css/common.css" rel="stylesheet">
   -->
-  <link href="css/mapping-tables.css" rel="stylesheet" />
-  <link href="css/common.css" rel="stylesheet" />
+  <link href="css/mapping-tables.css" rel="stylesheet">
+  <link href="css/common.css" rel="stylesheet">
   <!--end temporary replacement of CSS resources-->
-  <link href="css/html-aam.css" rel="stylesheet" />
+  <link href="css/html-aam.css" rel="stylesheet">
   <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
   <!-- Temporary replacement of these 4 script references to JS resources at rawgit.com with local sources until common solution for resources like these shared among different AAMs is found -->
   <!--
@@ -88,7 +88,6 @@
       },
 
       localBiblio: biblio,
-
       preProcess: [ linkCrossReferences ]
 
     };
@@ -377,13 +376,17 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-area">
-                <th><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-area-element"><code>area</code></a> <span class="el-context">(represents a <a href="https://www.w3.org/TR/html/links.html#hyperlink">hyperlink</a>)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-link"><code>link</code></a> role </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-area-element"><code>area</code></a> <span class="el-context">(represents a <a href="https://www.w3.org/TR/html/links.html#hyperlink">hyperlink</a>)</span>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-link"><code>link</code></a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-area-nohref">
                 <th><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-area-element"><code>area</code></a> <span class="el-context">(no <a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-href"><code>href</code></a> attribute)</span></th>
@@ -2277,7 +2280,9 @@
                     <span class="type">Role: </span><code>IA2_ROLE_TEXT_FRAME</code>
                   </div>
                 </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
+                <td class="uia">
+                  <div class="general">Not mapped</div>
+                </td>
                 <td class="atk">
                   <div class="general">
                     Not mapped if used as an image map, otherwise:
@@ -2293,25 +2298,57 @@
             <tr tabindex="-1" id="el-mark">
               <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-mark-element"><code>mark</code></a></th>
               <td class="aria">No corresponding role</td>
-              <td class="ia2"><div class="general"><span class="role"><span class="type">Role: </span> <code>IA2_ROLE_TEXT_FRAME</code></span></div>
-                <p><span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:mark</code></p>
-                <p><span class="general">Styles used are mapped to text attributes on the accessible object.</span></p>
-                <p><span class="ifaces"><span class="type">Interfaces: </span> <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;</span></p></td>
+              <td class="ia2">
+                <div class="general">
+                  <span class="role">
+                    <span class="type">Role: </span> <code>IA2_ROLE_TEXT_FRAME</code>
+                  </span>
+                </div>
+                <p>
+                  <span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:mark</code>
+                </p>
+                <p>
+                  <span class="general">Styles used are mapped to text attributes on the accessible object.</span>
+                </p>
+                <p>
+                  <span class="ifaces"><span class="type">Interfaces: </span> <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;</span>
+                </p>
+              </td>
               <td class="uia">
-                  <div class="ctrltype"> <span class="type">Control Type: </span><code>Text</code> </div>
-                  <div class="ctrltype"> <span class="type">Localized Control Type: </span><code>"mark"</code> </div>
+                <div class="ctrltype">
+                  <span class="type">Control Type: </span><code>Text</code>
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type: </span><code>"mark"</code>
+                </div>
               </td>
               <td class="atk"><div class="general">
-                <p class="role"><span class="type">Role: </span> <code>ATK_ROLE_STATIC</code></p>
+                <p class="role">
+                  <span class="type">Role: </span> <code>ATK_ROLE_STATIC</code>
+                </p>
               </div>
-                <p><span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:mark</code></p>
-                <p><span class="general">Styles used are mapped to text attributes on the accessible object.</span></p>
-                <div class="ifaces"> <span class="type">Interfaces: </span> <code>AtkText</code>; <code>AtkHypertext</code></div>
-                <p></p></td>
-              <td class="ax"><div class="role"> <span class="type">AXRole: </span><code>AXGroup</code></div>
-                <div class="subrole"> <span class="type">AXSubrole: </span><code>(nil)</code></div>
-                <div class="roledesc"> <span class="type">AXRoleDescription: </span><code>"highlighted content"</code></div></td>
-                <td class="comments"></td>
+                <p>
+                  <span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:mark</code>
+                </p>
+                <p>
+                  <span class="general">Styles used are mapped to text attributes on the accessible object.</span>
+                </p>
+                <div class="ifaces">
+                  <span class="type">Interfaces: </span> <code>AtkText</code>; <code>AtkHypertext</code>
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole: </span><code>AXGroup</code>
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole: </span><code>(nil)</code>
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription: </span><code>"highlighted content"</code>
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-math">
                 <th><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#mathml"><code>math</code></a></th>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en-US">
 <head>
   <meta charset="utf-8">
   <title>HTML Accessibility API Mappings 1.0</title>

--- a/index.html
+++ b/index.html
@@ -2292,7 +2292,13 @@
                     <code>ATK_ROLE_STATIC</code>
                   </div>
                 </td>
-                <td class="ax"><div class="general">Not mapped</div></td>
+                <td class="ax">
+                  <div class="general">
+                    <span class="type">Role: </span><code>AXImageMap</code> if used as an image map. Otherwise,<br>
+                    <span class="type">Role: </span><code>AXGroup</code> if associated with an <code>img</code> with no <code>alt</code>. Otherwise,<br>
+                    not mapped if not associated with an <code>img</code>.
+                  </div>
+                </td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-mark">


### PR DESCRIPTION
Closes #176

Adds `area` accessible name and accessible description computation steps.

Updates `map`'s mapping to match what is reported by AXAPI in different situations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/187.html" title="Last updated on May 21, 2019, 3:15 PM UTC (fac03a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/187/87236e8...fac03a7.html" title="Last updated on May 21, 2019, 3:15 PM UTC (fac03a7)">Diff</a>