### PR TITLE
Editorial: fix xref to core-aam-1.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
       	<li><cite><a href="https://developer.apple.com/reference/appkit/nsaccessibility">Mac OS X Accessibility Protocol Mac OS 10.10</a></cite> [[AXAPI]]</li>
       </ul>
       <p>If user agent developers need to expose information using other <a class="termref">accessibility APIs</a>, it is recommended that they work closely with the developer of the platform where the API runs, and assistive technology developers on that platform.</p>
-      <p>For more information regarding <a class="termref">accessibility APIs</a>, refer to <a href="https://www.w3.org/TR/core-aam-1.1/#intro_aapi">section 1.1 Accessibility APIs</a> of the <cite><a href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings</a></cite> [[core-aam-1.2]].</p>
+      <p>For more information regarding <a class="termref">accessibility APIs</a>, refer to <a data-cite="core-aam-1.2/#intro_aapi">section 1.1 Accessibility APIs</a> of the [[[core-aam-1.2]]].</p>
     </section>
   </section>
   <section id="conformance">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/202.html" title="Last updated on May 31, 2019, 4:43 AM UTC (200c9af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/202/47018b2...200c9af.html" title="Last updated on May 31, 2019, 4:43 AM UTC (200c9af)">Diff</a>