### PR TITLE
fix: bring back jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
   <link href="css/common.css" rel="stylesheet">
   <!--end temporary replacement of CSS resources-->
   <link href="css/html-aam.css" rel="stylesheet">
-  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="https://www.w3.org/scripts/jquery/2.2.4/jquery.min.js"></script>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
   <!-- Temporary replacement of these 4 script references to JS resources at rawgit.com with local sources until common solution for resources like these shared among different AAMs is found -->
   <!--
   <script src="https://rawgit.com/w3c/aria/master/common/script/resolveReferences.js" class="remove"></script>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/204.html" title="Last updated on Jun 3, 2019, 1:40 PM UTC (679a359)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/204/7df8952...679a359.html" title="Last updated on Jun 3, 2019, 1:40 PM UTC (679a359)">Diff</a>