### PR TITLE
Updates header/footer (not landmarks) to use ATK roles specific to each element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1318,7 +1318,7 @@
                 </td>
                 <td class="atk">
                   <div class="role">
-                    <span class="type">Role: </span><code>ATK_ROLE_SECTION</code>
+                    <span class="type">Role: </span><code>ATK_ROLE_FOOTER</code>
                   </div>
                   <div class="ifaces">
                     <span class="type">Interfaces: </span><code>AtkText</code>; <code>AtkHypertext</code>
@@ -1412,7 +1412,7 @@
                 <td class="atk">
                   <div class="role">
                     <span class="type">Role: </span>
-                    <code>ATK_ROLE_SECTION</code>
+                    <code>ATK_ROLE_HEADER</code>
                   </div>
                   <div class="ifaces">
                     <span class="type">Interfaces: </span>

--- a/index.html
+++ b/index.html
@@ -6155,6 +6155,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
+            <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>
             <li>21-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">GitHub issue #176</a>.</li>
             <li>11-Apr-2019: Update UIA mappings for <code>sub</code> and <code>sup</code> elements. See <a href="https://github.com/w3c/html-aam/pull/177">Pull request #177</a>.</li>
             <li>20-Mar-2019: Updated IA2 mappings for <code>sup</code> and <code>sub</code> elements. See <a href="https://github.com/w3c/html-aam/issues/174">GitHub issue #174</a>.</li>


### PR DESCRIPTION
Use [more specific ATK roles](https://developer.gnome.org/atk/stable/AtkObject.html#atk-role-for-name) to use when header/footer elements are *not* landmarks.

Closes #129


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/207.html" title="Last updated on Jun 10, 2019, 8:58 PM UTC (cfc508a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/207/828e3fa...cfc508a.html" title="Last updated on Jun 10, 2019, 8:58 PM UTC (cfc508a)">Diff</a>