### PR TITLE
Update mappings for ins and del elements: UIA, IA2, ATK

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,7 +701,9 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-canvas">
-                <th><a data-cite="HTML">`canvas`</a></th>
+                <th>
+                  <a data-cite="HTML">`canvas`</a>
+                </th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
                   <div class="role">
@@ -822,36 +824,37 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-code">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-code-element"><code>code</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
+              <th>
+                <a data-cite="HTML">`code`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">
+                  No accessible object. Styles used are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="uia">
                   <div class="general">
-                    No accessible object. Styles used are mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code>
-                    Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles used are
-                    mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+                    No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  No accessible object. Styles used are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-col">
                 <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-col-element"><code>col</code></a></th>
@@ -942,38 +945,40 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-del">
-                <th><a href="https://www.w3.org/TR/html/edits.html#the-del-element"><code>del</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role: </span><code>IA2_ROLE_CONTENT_DELETION</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type: </span><code>Text</code>
-                  </div>
-                  <div class="ctrltype">
-                    <span class="type">Localized Control Type: </span><code>"del"</code>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span><code>ATK_ROLE_SECTION</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>AXDeleteStyleGroup</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`del`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `IA2_ROLE_CONTENT_DELETION`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"del"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_SECTION`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXDeleteStyleGroup`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-details">
                 <th><a href="https://www.w3.org/TR/html/interactive-elements.html#the-details-element"><code>details</code></a></th>
@@ -2103,38 +2108,40 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-ins">
-                <th><a data-cite="HTML">`ins`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role: </span><code>IA2_ROLE_CONTENT_INSERTION</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type: </span><code>Text</code>
-                  </div>
-                  <div class="ctrltype">
-                    <span class="type">Localized Control Type: </span><code>"ins"</code>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span><code>ATK_ROLE_SECTION</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>AXInsertStyleGroup</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`ins`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `IA2_ROLE_CONTENT_INSERTION`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"ins"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_SECTION`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXInsertStyleGroup`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-kbd">
                 <th><a data-cite="HTML">`kbd`</a></th>
@@ -6159,6 +6166,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
+            <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>
             <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>
             <li>21-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">GitHub issue #176</a>.</li>
             <li>11-Apr-2019: Update UIA mappings for <code>sub</code> and <code>sup</code> elements. See <a href="https://github.com/w3c/html-aam/pull/177">Pull request #177</a>.</li>

--- a/index.html
+++ b/index.html
@@ -950,8 +950,11 @@
                   </div>
                 </td>
                 <td class="uia">
-                    <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code>
-                    Control Pattern implemented on a parent accessible object.
+                  <div class="ctrltype">
+                    <span class="type">Control Type: </span><code>Text</code>
+                  </div>
+                  <div class="ctrltype">
+                    <span class="type">Localized Control Type: </span><code>"del"</code>
                   </div>
                 </td>
                 <td class="atk">
@@ -2108,7 +2111,11 @@
                   </div>
                 </td>
                 <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
+                  <div class="ctrltype">
+                    <span class="type">Control Type: </span><code>Text</code>
+                  </div>
+                  <div class="ctrltype">
+                    <span class="type">Localized Control Type: </span><code>"ins"</code>
                   </div>
                 </td>
                 <td class="atk">

--- a/index.html
+++ b/index.html
@@ -945,9 +945,8 @@
                 <th><a href="https://www.w3.org/TR/html/edits.html#the-del-element"><code>del</code></a></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
-                  <div class="general">
-                    No accessible object. Styles used are mapped
-                    into text attributes on its text container.
+                  <div class="role">
+                    <span class="type">Role: </span><code>IA2_ROLE_CONTENT_DELETION</code>
                   </div>
                 </td>
                 <td class="uia">
@@ -956,9 +955,8 @@
                   </div>
                 </td>
                 <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles used are mapped
-                    into text attributes on its text container.
+                  <div class="role">
+                    <span class="type">Role: </span><code>ATK_ROLE_SECTION</code>
                   </div>
                 </td>
                 <td class="ax">
@@ -2105,8 +2103,8 @@
                 <th><a data-cite="HTML">`ins`</a></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
-                  <div class="general">
-                    No accessible object. Styles used are mapped into text attributes on its text container.
+                  <div class="role">
+                    <span class="type">Role: </span><code>IA2_ROLE_CONTENT_INSERTION</code>
                   </div>
                 </td>
                 <td class="uia">
@@ -2114,9 +2112,8 @@
                   </div>
                 </td>
                 <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles used are mapped
-                    into text attributes on its text container.
+                  <div class="role">
+                    <span class="type">Role: </span><code>ATK_ROLE_SECTION</code>
                   </div>
                 </td>
                 <td class="ax">


### PR DESCRIPTION
Closes #141

Updates `del` and `ins` mappings for:
* [UIA implementation commitment](https://github.com/w3c/html-aam/pull/206)
* [IA2](https://github.com/LinuxA11y/IAccessible2/blob/master/api/AccessibleRole.idl#L307)
* [ATK open issue to implement](https://gitlab.gnome.org/GNOME/atk/issues/2)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/213.html" title="Last updated on Jun 13, 2019, 12:34 PM UTC (dd70111)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/213/153f948...dd70111.html" title="Last updated on Jun 13, 2019, 12:34 PM UTC (dd70111)">Diff</a>