### PR TITLE
Issue 188: Remove and update menuitems and menu mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,18 +249,6 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-a-parentmenu">
-              <th>
-                <a data-cite="HTML">`a`</a>
-                <span class="el-context">(represents a <a data-cite="html">hyperlink</a> and parent is a menu)</span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-menuitem">`menuitem`</a> role </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
             <tr tabindex="-1" id="el-a-nohref">
               <th>
                 <a data-cite="HTML">`a`</a>
@@ -1532,27 +1520,9 @@
                 <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-input-button-parentmenu">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#button-state-typebutton">Button</a> state and parent is a menu)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
             <tr tabindex="-1" id="el-input-checkbox">
                 <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#checkbox-state-typecheckbox">Checkbox</a> state)</span></th>
                 <td class="aria"><a class="core-mapping" href="#role-map-checkbox"><code>checkbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedMixed"><code>aria-checked</code></a> state set to "mixed" if the element's <code>indeterminate</code> IDL attribute is true, or "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-checkbox-parentmenu">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#checkbox-state-typecheckbox">Checkbox</a> state and parent is a menu)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemcheckbox"><code>menuitemcheckbox</code></a> role</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1758,15 +1728,6 @@
                 <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-input-image-parentmenu">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#image-button-state-typeimage">Image Button</a> state and parent is a menu)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
             <tr tabindex="-1" id="el-input-localdateandtime">
                 <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span></th>
                 <td class="aria">No corresponding role</td>
@@ -1902,15 +1863,6 @@
             <tr tabindex="-1" id="el-input-radio">
                 <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-state-typeradio">Radio Button</a> state)</span></th>
                 <td class="aria"><a class="core-mapping" href="#role-map-radio"><code>radio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise. With <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize"><code>aria-setsize</code></a> value reflecting number of <code>type=radio input</code> elements within the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-group">radio button group</a>  and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset"><code>aria-posinset</code></a> value reflecting the<code> </code>elements position within the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-group">radio button group</a>. </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-radio-menuparent">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-input-element"><code>input</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-state-typeradio">Radio Button</a> state and parent is a menu)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>

--- a/index.html
+++ b/index.html
@@ -3960,8 +3960,7 @@
                 <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue"><code>aria-disabled</code></a>="true"</td>
                 <td class="ia2">
                   <div class="states">
-                    <span class="type">States: </span>
-                    <code>STATE_SYSTEM_UNAVAILABLE</code>
+                    <span class="type">States:</span> `STATE_SYSTEM_UNAVAILABLE`
                   </div>
                 </td>
                 <td class="uia"></td>
@@ -4284,14 +4283,16 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-kind">
-                <th><code>kind</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-track-kind"><code>track</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><code>kind</code></th>
+              <td class="elements">
+                <a data-cite="html/#element-attrdef-track-kind">`track`</a>
+              </td>
+              <td class="aria">Not mapped</td>
+              <td class="ia2">Not mapped</td>
+              <td class="uia">Not mapped</td>
+              <td class="atk">Not mapped</td>
+              <td class="ax">Not mapped</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-label">
               <th>`label`</th>
@@ -5011,19 +5012,6 @@
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>
-            <!-- <tr tabindex="-1" id="att-55">
-                <th><code>summary</code></th>
-                <td><a href="https://www.w3.org/TR/html51/obsolete.html#attr-table-summary"><code>table</code></a></td>
-                <td>Yes</td>
-                <td>Yes</td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>AXHelp</td>
-                <td></td>
-            </tr> -->
             <tr tabindex="-1" id="att-tabindex">
                 <th><code>tabindex</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-tabindex">HTML elements</a></td>
@@ -5085,14 +5073,12 @@
                 <td class="aria">?</td>
                 <td class="ia2">
                   <div class="name">
-                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
-                    <a class="termref">accessible description</a>
+                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then <a class="termref">accessible description</a>
                   </div>
                 </td>
                 <td class="uia">
                   <div class="name">
-                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
-                    <a class="termref">accessible description</a>
+                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then <a class="termref">accessible description</a>
                   </div>
                 </td>
                 <td class="atk">
@@ -5127,14 +5113,14 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-title-link">
-                <th><code>title</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-link-title"><code>link</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><code>title</code></th>
+              <td class="elements"><a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-link-title">`link`</a></td>
+              <td class="aria">Not mapped</td>
+              <td class="ia2">Not mapped</td>
+              <td class="uia">Not mapped</td>
+              <td class="atk">Not mapped</td>
+              <td class="ax">Not mapped</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-title-style">
                 <th><code>title</code></th>
@@ -5954,7 +5940,7 @@
     </section>
     <section>
       <h3>Text Level Elements Not Listed Elsewhere</h3>
-      <p><a data-cite="html">`abbr`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-b-element"><code>b</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdi-element"><code>bdi</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"><code>bdo</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-br-element"><code>br</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-cite-element"><code>cite</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-code-element"><code>code</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-dfn-element"><code>dfn</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-em-element"><code>em</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-i-element"><code>i</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-kbd-element"><code>kbd</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-mark-element"><code>mark</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-q-element"><code>q</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rp-element"><code>rp</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rt-element"><code>rt</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-ruby-element"><code>ruby</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-s-element"><code>s</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-samp-element"><code>samp</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-small-element"><code>small</code></a>, <a>`strong`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sub</code> and <code>sup</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-time-element"><code>time</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-u-element"><code>u</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-var-element"><code>var</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-wbr-element"><code>wbr</code></a></p>
+      <p><a data-cite="html">`abbr`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-b-element">`b`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdi-element">`bdi`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element">`bdo`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-br-element">`br`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-cite-element">`cite`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-code-element">`code`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-dfn-element">`dfn`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-em-element">`em`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-i-element">`i`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-kbd-element">`kbd`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-mark-element">`mark`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-q-element">`q`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rp-element">`rp`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rt-element">`rt`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-ruby-element">`ruby`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-s-element">`s`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-samp-element">`samp`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-small-element">`small`</a>, <a>`strong`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements">`sub` and `sup`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-time-element">`time`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-u-element">`u`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-var-element">`var`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-wbr-element">`wbr`</a></p>
       <section>
         <h4>Text Level Element Accessible Name Computation</h4>
         <ol>
@@ -6018,6 +6004,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
+            <li>17-June-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`.  Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a></li>
             <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>
             <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>
             <li>21-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">GitHub issue #176</a>.</li>

--- a/index.html
+++ b/index.html
@@ -2346,7 +2346,7 @@
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments">
-                The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a data-cite="HTML">`ul`</a> element, and has no implemented mappings or behavior similar to ARIA's <a class="core-mapping" href="#role-map-menu">`role="menu"`</a>.
+                The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a data-cite="HTML">`ul`</a> element. It has no implemented mappings or behavior that reflect the semantics of the ARIA <a class="core-mapping" href="#role-map-menu">`menu`</a> role.
               </td>
             </tr>
             <tr tabindex="-1" id="el-meta">

--- a/index.html
+++ b/index.html
@@ -3665,33 +3665,44 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-checked">
-                <th><code>checked</code> (if present)</th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-checked"><code>menuitem</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked"><code>input</code></a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> (state)="true"</td>
-                <td class="ia2">
-                  <div class="states">
-                    <span class="type">States: </span><code>STATE_SYSTEM_CHECKED</code>
-                  </div>
-                </td>
-                <td class="uia">Expose as <code>ToggleState</code> property in <code>Toggle</code> control pattern</td>
-                <td class="atk">
-                  <div class="states">
-                    <span class="type">States: </span>
-                    <code>ATK_STATE_CHECKED</code>
-                  </div>
-                </td>
-                <td class="ax"><code>AXValue: 1</code></td>
-                <td class="comments">If the element includes both the <code>checked</code> attribute and the <code>aria-checked</code> attribute with a valid value, User Agents MUST expose only the <code>checked</code> attribute value.</td>
+              <th>
+                `checked` (if present)
+              </th>
+              <td class="elements">
+                <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked">`input`</a>
+              </td>
+              <td class="aria">
+                <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="true"
+              </td>
+              <td class="ia2">
+                <div class="states">
+                  <span class="type">States:</span> `STATE_SYSTEM_CHECKED`
+                </div>
+              </td>
+              <td class="uia">Expose as `ToggleState` property in `Toggle` control pattern</td>
+              <td class="atk">
+                <div class="states">
+                  <span class="type">States:</span> `ATK_STATE_CHECKED`
+                </div>
+              </td>
+              <td class="ax">`AXValue: 1`</td>
+              <td class="comments">
+                If the element includes both the `checked` attribute and the `aria-checked` attribute with a valid value, User Agents MUST expose only the `checked` attribute value.
+              </td>
             </tr>
             <tr tabindex="-1" id="att-checked-absent">
-                <th><code>checked</code> (if absent)</th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-checked"><code>menuitem</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked"><code>input</code></a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaCheckedFalse"><code>aria-checked</code></a> (state)="false"</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia">Expose as <code>ToggleState</code> property in <code>Toggle</code> control pattern.</td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><code>AXValue: 0</code></td>
-                <td class="comments"></td>
+              <th>`checked` (if absent)</th>
+              <td class="elements">
+                <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked">`input`</a>
+              </td>
+              <td class="aria">
+                <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a> (state)="false"
+              </td>
+              <td class="ia2">Not mapped</td>
+              <td class="uia">Expose as `ToggleState` property in `Toggle` control pattern.</td>
+              <td class="atk">Not mapped</td>
+              <td class="ax">`AXValue: 0`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-cite">
                 <th><code>cite</code></th>
@@ -3941,7 +3952,7 @@
             </tr>
             <tr tabindex="-1" id="att-disabled">
                 <th><code>disabled</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>button</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-fieldset-disabled"><code>fieldset</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>input</code></a>; <a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-disabled"><code>menuitem</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-optgroup-disabled"><code>optgroup</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-option-disabled"><code>option</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>textarea</code></a></td>
+                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>button</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-fieldset-disabled"><code>fieldset</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>input</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-optgroup-disabled"><code>optgroup</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-option-disabled"><code>option</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>textarea</code></a></td>
                 <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue"><code>aria-disabled</code></a>="true"</td>
                 <td class="ia2">
                   <div class="states">
@@ -4238,16 +4249,6 @@
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="att-icon">
-                <th><code>icon</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-icon"><code>menuitem</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
-            </tr>
             <tr tabindex="-1" id="att-id">
                 <th><code>id</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/dom.html#element-attrdef-global-id">HTML elements</a></td>
@@ -4260,13 +4261,13 @@
             </tr>
             <tr tabindex="-1" id="att-indeterminate">
                 <th><code>indeterminate [IDL]</code></th>
-                <td class="elements">HTML elements; <a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-checked"><code>menuitem</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked"><code>input</code></a></td>
+                <td class="elements">HTML elements; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked"><code>input</code></a></td>
                 <td class="aria"><a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> (state)="mixed"</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments">If the element has the <code>indeterminate [IDL]</code>  set and the <code>aria-checked</code> attribute set, User Agents MUST expose only the<code>indeterminate [IDL]</code>state.</td>
+                <td class="ia2">Use WAI-ARIA mapping</td>
+                <td class="uia">Use WAI-ARIA mapping</td>
+                <td class="atk">Use WAI-ARIA mapping</td>
+                <td class="ax">Use WAI-ARIA mapping</td>
+                <td class="comments">If the element has the `indeterminate [IDL]` set and the `aria-checked` attribute set, User Agents MUST expose only the`indeterminate [IDL]` state.</td>
             </tr>
             <tr tabindex="-1" id="att-ismap">
                 <th><code>ismap</code></th>
@@ -4289,22 +4290,30 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-label">
-                <th><code>label</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-label"><code>menuitem</code></a>; <a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menu-label"><code>menu</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-optgroup-label"><code>optgroup</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-option-label"><code>option</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-track-label"><code>track</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="name">
-                    Associates the <a class="termref">accessible name</a>
-                  </div>
-                </td>
-                <td class="uia">The target element of the <code>label</code> attribute has a <code>LabeledBy</code> property pointing to the element with the <code>label</code> atrribute. Participates in <a href="#other-form-elements">name computation</a></td>
-                <td class="atk">
-                  <div class="name">
-                    Associates the <a class="termref">accessible name</a>
-                  </div>
-                </td>
-                <td class="ax"><code>AXTitle</code>:<code> &lt;value&gt;</code></td>
-                <td class="comments">See Also: <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a> </td>
+              <th>`label`</th>
+              <td class="elements">
+                <a data-cite="html/#attr-optgroup-label">`optgroup`</a>;
+                <a data-cite="html/#attr-option-label">`option`</a>;
+                <a data-cite="html/#attr-track-label">`track`</a>
+              </td>
+              <td class="aria">?</td>
+              <td class="ia2">
+                <div class="name">
+                  Associates the <a class="termref">accessible name</a>
+                </div>
+              </td>
+              <td class="uia">
+                The target element of the `label` attribute has a `LabeledBy` property pointing to the element with the `label` attribute. Participates in <a href="#other-form-elements">name computation.</a>
+              </td>
+              <td class="atk">
+                <div class="name">
+                  Associates the <a class="termref">accessible name</a>
+                </div>
+              </td>
+              <td class="ax">`AXTitle`: `&lt;value&gt;`</td>
+              <td class="comments">
+                See Also: <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>
+              </td>
             </tr>
             <tr tabindex="-1" id="att-lang">
                 <th><code>lang</code></th>
@@ -4701,16 +4710,6 @@
             <tr tabindex="-1" id="att-preload">
                 <th><code>preload</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-preload"><code>audio</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-preload"><code>video</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-radiogroup">
-                <th><code>radiogroup</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-radiogroup"><code>menuitem</code></a></td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
@@ -5120,32 +5119,7 @@
                     Associates the <a class="termref">accessible name</a>
                   </div>
                 </td>
-                <td class="ax"><code>AXExpandedTextValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-title-menuitem">
-                <th><code>title</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-title"><code>menuitem</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="name">
-                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
-                    <a class="termref">accessible description</a>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="name">
-                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
-                    <a class="termref">accessible description</a>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="name">
-                    Associates the <a class="termref">accessible name</a> or if it was provided otherwise then
-                    <a class="termref">accessible description</a>
-                  </div>
-                </td>
-                <td class="ax"><code>AXHelp: &lt;value&gt;</code></td>
+                <td class="ax">`AXExpandedTextValue: &lt;value&gt;`</td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-title-link">
@@ -5261,31 +5235,7 @@
                 <td class="ax">?</td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="att-type-menuitem">
-                <th><code>type</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menuitem-type"><code>menuitem</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="general">
-                    Defines the accessible role and states, refer to
-                    type="<a href="#el-menuitem-command"><code>command</code></a>"
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    Defines the accessible role and states, refer to
-                    type="<a href="#el-menuitem-command"><code>command</code></a>"
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    Defines the accessible role and states:
-                    type="<a href="#el-menuitem-command"><code>command</code></a>"
-                  </div>
-                </td>
-                <td class="ax">?</td>
-                <td class="comments"></td>
-            </tr>
+
             <tr tabindex="-1" id="att-type-ol">
                 <th><code>type</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/grouping-content.html#element-attrdef-ol-type"><code>ol</code></a></td>

--- a/index.html
+++ b/index.html
@@ -2337,13 +2337,17 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-menu">
-                <th><a href="https://www.w3.org/TR/html/interactive-elements.html#the-menu-element"><code>menu</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menu-type"><code>type</code></a> attribute in the <a href="https://www.w3.org/TR/html/interactive-elements.html#statedef-menu-popup-menu">popup menu</a> state)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menu"><code>menu</code></a> role </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`menu`</a>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-list">`list`</a> role </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a data-cite="HTML">`ul`</a> element, and has no implemented mappings or behavior similar to ARIA's <a class="core-mapping" href="#role-map-menu">`role="menu"`</a>.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-meta">
                 <th><a data-cite="HTML">`meta`</a></th>

--- a/index.html
+++ b/index.html
@@ -2393,33 +2393,6 @@
                 <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-menuitem-checkbox">
-                <th><a href="https://www.w3.org/TR/html/interactive-elements.html#elementdef-menuitem"><code>menuitem</code></a> <span class="el-context">(<code>type</code> attribute in the Checkbox state)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemcheckbox"><code>menuitemcheckbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the <code>checked</code> attribute is present, and "false" otherwise</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-menuitem-command">
-                <th><a href="https://www.w3.org/TR/html/interactive-elements.html#elementdef-menuitem"><code>menuitem</code></a> <span class="el-context">(<code>type</code> attribute in the Command state)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-menuitem-radio">
-                <th><a href="https://www.w3.org/TR/html/interactive-elements.html#elementdef-menuitem"><code>menuitem</code></a> <span class="el-context">(<code>type</code> attribute in the Radio state)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the <code>checked</code> attribute is present, and "false" otherwise</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
             <tr tabindex="-1" id="el-meta">
                 <th><a data-cite="HTML">`meta`</a></th>
                 <td class="aria">No corresponding role</td>

--- a/index.html
+++ b/index.html
@@ -884,33 +884,6 @@
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>
-             <!--<tr tabindex="-1" id="el-command-checkbox">
-               <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html/interactive-elements.html#menuitem-defines-a-command">defines a command</a>, whose <a href="https://www.w3.org/TR/html/sec-forms.html#element-statedef-input-checkbox">Type</a> facet is "checkbox", and that is a descendant of a <a href="https://www.w3.org/TR/html/interactive-elements.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html/interactive-elements.html#attr-valuedef-menu-type-context">context</a> state</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemcheckbox"><code>menuitemcheckbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the command's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">Checked State</a> facet is true, and "false" otherwise </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-command-command">
-                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html52/semantics.html#commands">defines a command</a>, whose <a href="https://www.w3.org/TR/html52/semantics.html#command-facet-type">Type</a> facet is "command", and that is a descendant of a <a href="https://www.w3.org/TR/html52/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html52/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html52/semantics.html#toolbar-state">toolbar</a> state</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitem"><code>menuitem</code></a> role </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-command-radio">
-                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html52/semantics.html#commands">defines a command</a>, whose <a href="https://www.w3.org/TR/html52/semantics.html#command-facet-type">Type</a> facet is "radio", and that is a descendant of a <a href="https://www.w3.org/TR/html52/semantics.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html52/semantics.html#attr-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html52/semantics.html#toolbar-state">toolbar</a> state</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-menuitemradio"><code>menuitemradio</code></a> role, with the <a class="core-mapping" href="#ariaCheckedTrue"><code>aria-checked</code></a> state set to "true" if the command's <a href="https://www.w3.org/TR/html52/semantics.html#command-facet-checkedstate">Checked State</a> facet is true, and "false" otherwise </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
-            </tr>-->
             <tr tabindex="-1" id="el-data">
                 <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-data-element"><code>data</code></a></th>
                 <td class="aria"></td>

--- a/index.html
+++ b/index.html
@@ -2458,7 +2458,10 @@
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments">
-                The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a data-cite="HTML">`ul`</a> element. It has no implemented mappings or behavior that reflect the semantics of the ARIA <a class="core-mapping" href="#role-map-menu">`menu`</a> role.
+                <div class="general">The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a href="el-ul">`ul`</a> element. It has no implemented mappings or behavior that reflect the semantics of the ARIA <a class="core-mapping" href="#role-map-menu">`menu`</a> role.</div>
+                <div class="general">
+                  Note obsolete <a data-cite="html/obsolete.html#menuitem">`menuitem` element</a>
+                  and <a data-cite="html/obsolete.html#attr-menu-type">`menu` with `type` attribute</a>.</div>
               </td>
             </tr>
             <tr tabindex="-1" id="el-meta">
@@ -6131,8 +6134,8 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
+            <li>11-Sept-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`.  Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a>.</li>
             <li>10-July-2019: Further updated mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/pull/219">GitHub pull request #219</a>.</li>
-            <li>10-July-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`.  Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a>.</li>
             <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>
             <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>
             <li>21-May-2019: Update AXAPI mappings for <code>map</code> element. Add accessible name and description computation for <code>area</code>. See <a href="https://github.com/w3c/html-aam/issues/176">GitHub issue #176</a>.</li>


### PR DESCRIPTION
Closes #188 

removed element mappings for:
- a with parent menu
- button with parent menu
- input type=checkbox with parent menu
- input type=image with parent menu
- input type=radio with parent menu
- menuitem type=checkbox
- menuitem type=command
- menuitem type=radio

removed attribute mappings for:
- checked referencing menuitem types
- disabled referencing menuitem
- icon for menuitem element
- label referencing menu and menuitem elements
- radiogroup for menuitem element
- title for menuitem element

menu updated to map to role=list
  - add comment for info on role=menu to see ARIA


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/214.html" title="Last updated on Sep 11, 2019, 1:29 PM UTC (6056938)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/214/24f3ea1...6056938.html" title="Last updated on Sep 11, 2019, 1:29 PM UTC (6056938)">Diff</a>