### PR TITLE
Editorial: update various links and code elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
     <section id="mapping_general">
       <h3>General Rules for Exposing WAI-ARIA Semantics</h3>
       <p class="note">
-          WAI-ARIA support was first introduced to HTML in [[HTML5]].
+        WAI-ARIA support was first introduced to HTML in [[HTML5]].
       </p>
       <p>
         Where an HTML element or attribute has default WAI-ARIA semantics, it MUST be exposed to the platform <a class="termref">accessibility APIs</a> in a way that conforms to <a class="core-mapping" href="#mapping_general">General rules for exposing WAI-ARIA semantics</a> in the [[[core-aam-1.2]]].
@@ -187,8 +187,8 @@
         <section data-cite="HTML">
           <h5>Use of MSAA VARIANT by Some <a class="termref">User Agents</a></h5>
           <p>In MSAA, the value of an <a>accessible object</a>'s <a href="https://docs.microsoft.com/en-us/windows/desktop/WinAuto/role-property">Role property</a> is retrieved with the <a href="https://docs.microsoft.com/en-us/windows/desktop/api/oleacc/nf-oleacc-iaccessible-get_accrole">IAccessible::get_accRole method</a>. This method returns a <a href="https://docs.microsoft.com/en-us/windows/desktop/api/oaidl/ns-oaidl-tagvariant">VARIANT</a> that is limited to a finite number of <a href="https://docs.microsoft.com/en-us/windows/desktop/WinAuto/object-roles">integer role constants</a> insufficient for describing the role of every HTML element, especially new elements introduced by HTML. To address this limitation, some user agents, e.g., Firefox and Chrome in cooperation with some screen readers, have elected to expose certain roles by returning a string value (<a href="https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr">BSTR</a>) in that VARIANT in a way that is not described by the MSAA specification.</p>
-          <p>For example, Firefox returns the element's tag name as a BSTR for the following: <a>abbr</a>, <a>address</a>, <a>aside</a>, <a>blockquote</a>, <a>canvas</a>, <a>caption</a>, <a>dd</a>, <a>div</a>, <a>figcaption</a>, <a>footer</a>, <a>form</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">h1–h6</a>, <a>header</a>, <a>iframe</a>, <a data-cite="html/input.html#file-upload-state-(type=file)">input type="file"</a>, <a>main</a>, <a>menu</a>, <a>nav</a>, <a>output</a>, <a>p</a>, <a>pre</a>, <a>q</a>, <a>section</a>, <a>time</a>.</p>
-          <p>Similarly, Chrome returns the element's tag name for: <a>blockquote</a>, <a>div</a>, <a>dl</a>, <a>figcaption</a>, <a>form</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">h1-h6</a>, <a>menu</a>, <a>meter</a>, <a>p</a>, <a>pre</a>.</p>
+          <p>For example, Firefox returns the element's tag name as a BSTR for the following: <a>`abbr`</a>, <a>`address`</a>, <a>`aside`</a>, <a>`blockquote`</a>, <a>`canvas`</a>, <a>`caption`</a>, <a>`dd`</a>, <a>`div`</a>, <a>`figcaption`</a>, <a>`footer`</a>, <a>`form`</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`–`h6`</a>, <a>`header`</a>, <a>`iframe`</a>, <a data-cite="html/input.html#file-upload-state-(type=file)">`input type="file"`</a>, <a>`main`</a>, <a>`menu`</a>, <a>`nav`</a>, <a>`output`</a>, <a>`p`</a>, <a>`pre`</a>, <a>`q`</a>, <a>`section`</a>, <a>`time`</a>.</p>
+          <p>Similarly, Chrome returns the element's tag name for: <a>`blockquote`</a>, <a>`div`</a>, <a>`dl`</a>, <a>`figcaption`</a>, <a>`form`</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`–`h6`</a>, <a>`menu`</a>, <a>`meter`</a>, <a>`p`</a>, <a>`pre`</a>.</p>
         </section>
         <section>
           <h5>Use of the DOM by Some Assistive Technologies</h5>
@@ -198,7 +198,7 @@
     </section>
     <section>
       <h3>HTML Element Role Mappings</h3>
-    	<p><strong>Notes:</strong> </p>
+    	<p><strong>Notes:</strong></p>
     	<ul>
     		<li>HTML elements with default WAI-ARIA role semantics MUST be mapped to platform <a class="termref">accessibility APIs</a> according to those WAI-ARIA roles' mappings as defined in the [[core-aam-1.2]] specification.</li>
         <li>A '?' in a cell indicates the data has yet to be provided.</li>
@@ -264,7 +264,7 @@
             <tr tabindex="-1" id="el-a-nohref">
               <th>
                 <a data-cite="HTML">`a`</a>
-                <span class="el-context">(no <a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-href">`href`</a> attribute)</span>
+                <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -406,7 +406,7 @@
             <tr tabindex="-1" id="el-area-nohref">
               <th>
                 <a data-cite="HTML">`area`</a>
-                <span class="el-context">(no <a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-href">`href`</a> attribute)</span>
+                <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -431,7 +431,9 @@
               <th>
                 <a data-cite="HTML">`article`</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-article">`article`</a> role </td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-article">`article`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -442,7 +444,9 @@
               <th>
                 <a data-cite="HTML">`aside`</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-complementary">`complementary`</a> role </td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia">
                 <div class="general">Use WAI-ARIA mapping</div>
@@ -692,13 +696,17 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-button">
-                <th><a data-cite="HTML">`button`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-button"><code>button</code></a> role </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`button`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-button"><code>button</code></a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-canvas">
                 <th>
@@ -738,90 +746,90 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-caption">
-                <th><a data-cite="HTML">`caption`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_CAPTION</code>
-                  </div>
-                  <div class="states">
-                    <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
-                  </div>
-                  <div class="relations">
-                    <span class="type">Relations: </span>
-                    <code>IA2_RELATION_LABEL_FOR</code> with parent <a href="#el-table"><code>table</code></a>
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span>
-                    <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Text</code>
-                    </div>
-                    <div class="properties">
-                        <span class="type">Other properties: </span>The <code>LabeledBy</code> property for the parent <a href="#el-table"><code>table</code></a> element points to the UIA element for the <code>caption</code> element
-                    </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span>
-                    <code>ATK_ROLE_CAPTION</code>
-                  </div>
-                  <div class="relations">
-                    <span class="type">Relations: </span>
-                    <code>ATK_RELATION_LABEL_FOR</code> with parent <a href="#el-table"><code>table</code></a>
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span>
-                    <code>AtkText</code>; <code>AtkHypertext</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`caption`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_CAPTION`
+                </div>
+                <div class="states">
+                  <span class="type">States:</span> `STATE_SYSTEM_READONLY`
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span>
+                  `IA2_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="properties">
+                  <span class="type">Other properties:</span> The `LabeledBy` property for the parent <a href="#el-table">`table`</a> element points to the UIA element for the `caption` element
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_CAPTION`
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span>
+                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-cite">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-cite-element"><code>cite</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">
-                    No accessible object. Styles used are mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code>
-                    Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles used are
-                    mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`cite`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">
+                  No accessible object. Styles used are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  No accessible object. Styles used are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-code">
               <th>
@@ -834,8 +842,8 @@
                 </div>
               </td>
               <td class="uia">
-                  <div class="general">
-                    No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
+                <div class="general">
+                  No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
                 </div>
               </td>
               <td class="atk">
@@ -857,32 +865,39 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-col">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-col-element"><code>col</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`col`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-colgroup">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-colgroup-element"><code>colgroup</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>
+              <th>
+                <a data-cite="HTML">`colgroup`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  <div class="ctrltype">
+                    <span class="type">Control Type:</span> `Group`
                   </div>
-                </td>
-                <td class="uia">
-                    <div class="general">
-                      <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Group</code>
-                      </div>
-                      <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"colgroup"</code></div>                    </div>
-                </td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+                  <div class="ctrltype">
+                    <span class="type">Localized Control Type:</span> `"colgroup"`
+                  </div>
+                </div>
+              </td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
              <!--<tr tabindex="-1" id="el-command-checkbox">
                <th>Command: <span class="el-context">an element that <a href="https://www.w3.org/TR/html/interactive-elements.html#menuitem-defines-a-command">defines a command</a>, whose <a href="https://www.w3.org/TR/html/sec-forms.html#element-statedef-input-checkbox">Type</a> facet is "checkbox", and that is a descendant of a <a href="https://www.w3.org/TR/html/interactive-elements.html#the-menu-element"><code>menu</code></a> element whose <a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menu-type"><code>type</code></a> attribute is in the <a href="https://www.w3.org/TR/html/interactive-elements.html#attr-valuedef-menu-type-context">context</a> state</span></th>
@@ -912,37 +927,43 @@
                 <td class="comments"></td>
             </tr>-->
             <tr tabindex="-1" id="el-data">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-data-element"><code>data</code></a></th>
-                <td class="aria"></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`data`</a>
+              </th>
+              <td class="aria"></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-datalist">
-                <th>
-                  <a href="https://www.w3.org/TR/html/sec-forms.html#the-datalist-element"><code>datalist</code></a>
-                  (represents pre-defined options for <code>input</code> element)
-                </th>
-                <td class="aria"><a class="core-mapping" href="#role-map-listbox"><code>listbox</code></a> role, with the <a class="core-mapping" href="#ariaMultiselectableFalse"><code>aria-multiselectable</code></a> property set to "true" if the <code>datalist</code>'s selection model allows multiple <code>option</code> elements to be selected at a time, and "false" otherwise</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments">
-                  If <code>datalist</code> is not linked to a proper <code>input</code> element,
-                  then <code>datalist</code> element is not mapped to accessibility APIs.
-                </td>
+              <th>
+                <a data-cite="HTML">`datalist`</a>
+                (represents pre-defined options for `input` element)
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-listbox">`listbox`</a> role, with the <a class="core-mapping" href="#ariaMultiselectableFalse">`aria-multiselectable`</a> property set to "true" if the `datalist`'s selection model allows multiple `option` elements to be selected at a time, and "false" otherwise</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                If `datalist` is not linked to a proper `input` element, then `datalist` element is not mapped to accessibility APIs.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-dd">
-                <th><a href="https://www.w3.org/TR/html/grouping-content.html#the-dd-element"><code>dd</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-definition"><code>definition</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`dd`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-definition">`definition`</a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-del">
               <th>
@@ -981,392 +1002,474 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-details">
-                <th><a href="https://www.w3.org/TR/html/interactive-elements.html#the-details-element"><code>details</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type:</span> `Group`
-                  </div>
-                  <div class="ctrltype">
-                    <span class="type">Localized Control Type:</span> `"details"`
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span> `ATK_ROLE_PANEL`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`details`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Group`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"details"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_PANEL`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-dfn">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-dfn-element"><code>dfn</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-term"><code>term</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`dfn`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-term">`term`</a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-dialog">
-                <th><a href="https://w3c.github.io/html/interactive-elements.html#the-dialog-element"><code>dialog</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-dialog"><code>dialog</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`dialog`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-dialog">`dialog`</a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-div">
-                <th><a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><code>div</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">
-                    May not have an accessible object if has no semantic meaning. Otherwise,
-                  </div>
-                  <div class="role">
-                    <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span>
-                    <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype"><span class="type">Control Type: </span><code>Group</code></div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    May not have an accessible object if has no semantic meaning. Otherwise,
-                  </div>
-                  <div class="role">
-                    <span class="type">Role: </span>
-                    <code>ATK_ROLE_SECTION</code>
-                  </div>
-                   <div class="ifaces">
-                    <span class="type">Interfaces: </span><code>AtkText</code>; <code>AtkHypertext</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`div`</a>
+              </th>
+              <td class="aria">
+                No corresponding role
+              </td>
+              <td class="ia2">
+                <div class="general">
+                  May not have an accessible object if has no semantic meaning. Otherwise,
+                </div>
+                <div class="role">
+                  <span class="type">Roles:</span> <code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces: </span>
+                  <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype"><span class="type">Control Type:</span> <code>Group</code></div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  May not have an accessible object if has no semantic meaning. Otherwise,
+                </div>
+                <div class="role">
+                  <span class="type">Role: </span>
+                  <code>ATK_ROLE_SECTION</code>
+                </div>
+                 <div class="ifaces">
+                  <span class="type">Interfaces:</span> <code>AtkText</code>; <code>AtkHypertext</code>
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> <code>AXGroup</code>
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> <code>(nil)</code>
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> <code>"group"</code>
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-dl">
-                <th><a href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element"><code>dl</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role: </span><code>ROLE_SYSTEM_LIST</code>
-                  </div>
-                  <div class="states">
-                    <span class="type">States: </span><code>STATE_SYSTEM_READONLY</code>
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>List</code>
-                    </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span>
-                    <code>ATK_ROLE_DESCRIPTION_LIST</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXList</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>AXDefinitionList</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"definition list"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`dl`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> <code>ROLE_SYSTEM_LIST</code>
+                </div>
+                <div class="states">
+                  <span class="type">States:</span> <code>STATE_SYSTEM_READONLY</code>
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> <code>List</code>
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> <code>ATK_ROLE_DESCRIPTION_LIST</code>
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> <code>AXList</code>
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> <code>AXDefinitionList</code>
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> <code>"definition list"</code>
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-dt">
-                <th><a href="https://www.w3.org/TR/html/grouping-content.html#the-dt-element"><code>dt</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-term"><code>term</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`dt`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-term">`term`</a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-em">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-em-element"><code>em</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">
-                    No accessible object. Styles used are mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attributes of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles used are mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`em`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">
+                  No accessible object. Styles used are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  No accessible object. Styles used are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-embed">
-                <th><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-embed-element"><code>embed</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles: </span><code>ROLE_SYSTEM_CLIENT</code>; <code>IA2_ROLE_EMBEDDED_OBJECT</code>
-                  </div>
-                  <div class="states">
-                    <span class="type">States: </span><code>STATE_SYSTEM_UNAVAILABLE</code> for windowless plugin
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Pane</code>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span>
-                    <code>ATK_ROLE_EMBEDDED</code>
-                  </div>
-                </td>
-                <td class="ax">Depends on format of data file</td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`embed`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Roles:</span> `ROLE_SYSTEM_CLIENT`; `IA2_ROLE_EMBEDDED_OBJECT`
+                </div>
+                <div class="states">
+                  <span class="type">States:</span> `STATE_SYSTEM_UNAVAILABLE` for windowless plugin
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Pane`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_EMBEDDED`
+                </div>
+              </td>
+              <td class="ax">Depends on format of data file</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-fieldset">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-fieldset-element"><code>fieldset</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-group"><code>group</code></a> role</td>
-                <td class="ia2">
-                  <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
-                  <div class="relations">
-                    <span class="type">Relations:</span><code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-legend"><code>legend</code></a> element
+              <th>
+                <a data-cite="HTML">`fieldset`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-group">`group`</a> role
+              </td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</span>
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole: </span><code>AXFieldset</code>
+                </div>
+                <div class="roledesc">
+                  <div class="role-namefrom">
+                    <strong>AXDescription:</strong> value from child <a href="#el-legend">`legend`</a> subtree
                   </div>
-                </td>
-                <td class="uia">
-                    <div class="ctrltype"><span class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</span></div>
-                </td>
-                <td class="atk">
-                  <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
-                  <div class="relations">
-                    <span class="type">Relations:</span>
-                    <code>ATK_RELATION_LABELLED_BY</code> with child <a href="#el-legend"><code>legend</code></a> element
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>AXFieldset</code>
-                    </div>
-                  <div class="roledesc"></div>
-                    <div class="role-namefrom"><strong>AXDescription:</strong> value from child <a href="#el-legend"><code>legend</code></a> subtree</div>
-                </td>
-                <td class="comments"></td>
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-figcaption">
-                <th><a data-cite="HTML">`figcaption`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles: </span><code>ROLE_SYSTEM_TEXT</code>; <code>IA2_ROLE_CAPTION</code>
-                  </div>
-                  <div class="relations">
-                    <span class="type">Relations: </span><code>IA2_RELATION_LABEL_FOR</code> with parent <a href="#el-figure"><code>figure</code></a> element
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span>
-                    <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Text</code>
-                    </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span>
-                    <code>ATK_ROLE_CAPTION</code>
-                  </div>
-                  <div class="relations">
-                    <span class="type">Relations: </span>
-                    <code>ATK_RELATION_LABEL_FOR</code> with parent <a href="#el-figure"><code>figure</code></a> element
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span>
-                    <code>AtkText</code>; <code>AtkHypertext</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`figcaption`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_CAPTION`
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_CAPTION`
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span>
+                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-figure">
-                <th>
-                  <a href="https://www.w3.org/TR/html/grouping-content.html#the-figure-element"><code>figure</code></a>
-                </th>
-                <td class="aria">
-                  <a class="core-mapping" href="#role-map-figure"><code>figure</code></a> role
-                </td>
-                <td class="ia2">
-                  <div class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</div>
-                  <div class="relations">
-                    <span class="type">Relations: </span><code>IA2_RELATION_LABELLED_BY</code> with child <a href="#el-figcaption"><code>figcaption</code></a> element
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    Use WAI-ARIA mapping
-                  </div>
-                  <div class="general">
-                    Accessible name derived from <code>figcaption</code> according to the <a href="#figure-element-accessible-name-computation"><code>figure</code> Element Accessible Name Computation</a>
-                  </div>
+              <th>
+                <a data-cite="HTML">`figure`</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-figure">`figure`</a> role
               </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span>Use WAI-ARIA mapping</div>
-                  <div class="name">
-                    <span class="type">Name: </span>
-                    related <a href="#el-figcaption"><code>figcaption</code></a> content
-                  </div>
-                  <div class="relations">
-                    <span class="type">Relations: </span>
-                    <code>ATK_RELATION_LABELLED_BY</code> with child <a href="#el-figcaption"><code>figcaption</code></a> element
-                  </div>
-                </td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
+                </div>
+              </td>
+              <td class="uia">
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
+                </div>
+                <div class="general">
+                  Accessible name derived from `figcaption` according to the <a href="#figure-element-accessible-name-computation">`figure` Element Accessible Name Computation</a>
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping</div>
+                <div class="name">
+                  <span class="type">Name:</span> related <a href="#el-figcaption">`figcaption`</a> content
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
+                </div>
+              </td>
               <td class="ax">
-                <div class="role"><span class="type">AXRole: </span>Use WAI-ARIA mapping</div>
+                <div class="role">
+                  <span class="type">AXRole:</span> Use WAI-ARIA mapping
+                </div>
                 <div class="subrole"></div>
               </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-footer-ancestorbody">
-                <th><a href="https://www.w3.org/TR/html/sections.html#the-footer-element"><code>footer</code></a> (scoped to the <a href="https://www.w3.org/TR/html/sections.html#the-body-element"><code>body</code></a> element)</th>
-                <td class="aria"><a class="core-mapping" href="#role-map-contentinfo"><code>contentinfo</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia">
-                  <div class="general">Use WAI-ARIA mapping</div>
-                  <div class="ctrltype"><span class="type">Localized Control Type: </span><code>"footer"</code></div>
-                </td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax">
-                  <div class="general">Use WAI-ARIA mapping</div>
-                  <div class="roledesc"><span class="type">AXRoleDescription: </span><code>"footer"</code></div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`body`</a> element)
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-contentinfo">`contentinfo`</a> role
+              </td>
+              <td class="ia2">
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+              <td class="uia">
+                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"footer"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+              <td class="ax">
+                <div class="general">Use WAI-ARIA mapping</div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"footer"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-footer">
-                <th><a href="https://www.w3.org/TR/html/sections.html#the-footer-element"><code>footer</code></a> (scoped to the <a href="https://www.w3.org/TR/html/grouping-content.html#the-main-element"><code>main</code></a> element, a <a href="https://www.w3.org/TR/html/dom.html#sectioning-content">sectioning content</a> element, or a <a href="https://www.w3.org/TR/html/sections.html#sectioning-roots">sectioning root</a> element other than <a href="https://www.w3.org/TR/html/sections.html#the-body-element"><code>body</code></a>)</th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span>
-                    <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Group</code>
-                    </div>
-                    <div class="ctrltype">
-                        <span class="type">Localized Control Type: </span><code>"footer"</code>
-                    </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span><code>ATK_ROLE_FOOTER</code>
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces: </span><code>AtkText</code>; <code>AtkHypertext</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element, or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="HTML">`body`</a>)
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Group`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"footer"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_FOOTER`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-form">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-form-element"><code>form</code></a> with an <a class="termref">accessible name</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-form "><code>form</code></a> role </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`form`</a> with an <a class="termref">accessible name</a>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-form ">`form`</a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr id="el-header2" tabindex="-1">
-              <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-form-element"><code>form</code></a> without an <a class="termref">accessible name</a></th>
+              <th>
+                <a data-cite="HTML">`form`</a> without an <a class="termref">accessible name</a>
+              </th>
               <td class="aria">No corresponding role</td>
-              <td class="ia2"><div class="role"> <span class="type">Role: </span><code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code> </div>
-                <div class="ifaces"> <span class="type">Interfaces: </span><code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>; </div></td>
-              <td class="uia"><div class="ctrltype"> <span class="type">Control Type: </span><code>Group</code> </div>
-                <div class="ctrltype"> <span class="type">Localized Control Type: </span><code>"form"</code> </div></td>
-              <td class="atk"><div class="role"> <span class="type">Role: </span> <code>ATK_ROLE_SECTION</code> </div>
-                <div class="ifaces"> <span class="type">Interfaces: </span> <code>AtkText</code>; <code>AtkHypertext</code> </div></td>
-              <td class="ax"><div class="role"> <span class="type">AXRole: </span><code>AXGroup</code> </div>
-                <div class="subrole"> <span class="type">AXSubrole: </span><code>(nil)</code> </div>
-                <div class="roledesc"> <span class="type">AXRoleDescription: </span><code>"group"</code> </div></td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Group`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"form"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role: </span> `ATK_ROLE_SECTION`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces: </span> `AtkText`; `AtkHypertext`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-h1-h6">


### PR DESCRIPTION
* update links to point to WHATWG HTML specification
* convert `<code>` elements to markdown
* other minor code formatting updates


The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors or warnings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/216.html" title="Last updated on Jul 3, 2019, 12:39 AM UTC (19733a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/216/f305588...19733a0.html" title="Last updated on Jul 3, 2019, 12:39 AM UTC (19733a0)">Diff</a>