### PR TITLE
Editorial: another batch of linking updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -6121,28 +6121,28 @@
       </section>
     </section>
     <section>
-      <h3><code>area</code> Element</h3>
+      <h3>`area` Element</h3>
       <section>
-        <h4><code>area</code> Element Accessible Name Computation</h4>
+        <h4>`area` Element Accessible Name Computation</h4>
         <ol>
           <li>
-           If the <code>area</code> element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+           If the `area` element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label">`aria-label`</a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby">`aria-labelledby`</a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
-          <li>Otherwise use <code>area</code> element's <code>alt</code> attribute.</li>
-          <li>Otherwise use the <code>title</code> attribute.</li>
+          <li>Otherwise use `area` element's `alt` attribute.</li>
+          <li>Otherwise use the `title` attribute.</li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.
           </li>
         </ol>
       </section>
       <section>
-        <h4><code>area</code> Element Accessible Description Computation</h4>
+        <h4>`area` Element Accessible Description Computation</h4>
         <ol>
           <li>
-            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby">`aria-describedby`</a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>
-            Otherwise use the <code>title</code> attribute if it wasn't used as the <a class="termref">accessible name</a>.
+            Otherwise use the `title` attribute if it wasn't used as the <a class="termref">accessible name</a>.
           </li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible description</a>.
@@ -6151,28 +6151,28 @@
       </section>
     </section>
     <section>
-      <h3><code>iframe</code> Element</h3>
+      <h3>`iframe` Element</h3>
       <section>
-        <h4><code>iframe</code> Element Accessible Name Computation</h4>
+        <h4>`iframe` Element Accessible Name Computation</h4>
         <ol>
-          <li>If the element  has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+          <li>If the element  has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label">`aria-label`</a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby">`aria-labelledby`</a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
-          <li>Otherwise use the <code>title</code> attribute.</li>
+          <li>Otherwise use the `title` attribute.</li>
           <li>If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.</li>
         </ol>
         <div class="note">
           <div class="note-title marker" id="xxx" role="heading" aria-level="5"></div>
-          <p>The document referenced by the <code>src</code> of the <code>iframe</code> element gets its name from that document's <code>title</code> element, like any other document. If there is no <code>title</code> provided, there is no accessible name.</p>
+          <p>The document referenced by the `src` of the `iframe` element gets its name from that document's `title` element, like any other document. If there is no `title` provided, there is no accessible name.</p>
         </div>
       </section>
       <section>
-        <h4><code>iframe</code> Element Accessible Description Computation</h4>
+        <h4>`iframe` Element Accessible Description Computation</h4>
         <ol>
           <li>
-            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby">`aria-describedby`</a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>
-            Otherwise use the <code>title</code> attribute if it wasn't used as the <a class="termref">accessible name</a>.
+            Otherwise use the `title` attribute if it wasn't used as the <a class="termref">accessible name</a>.
           </li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible description</a>.
@@ -6181,14 +6181,14 @@
       </section>
     </section>
     <section>
-      <h3><a href="https://www.w3.org/TR/html/sections.html#sections">Section</a> Elements and <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">Grouping Content</a> Elements Not listed Elsewhere</h3>
+      <h3><a data-cite="HTML/sections.html#sections">Section</a> Elements and <a data-cite="HTML/grouping-content.html#grouping-content">Grouping Content</a> Elements Not listed Elsewhere</h3>
       <section>
         <h4>Section and Grouping Element Accessible Name Computation</h4>
         <ol>
           <li>
-            If the element  has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the element  has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label">`aria-label`</a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby">`aria-labelledby`</a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
-          <li>Otherwise use the <code>title</code> attribute.</li>
+          <li>Otherwise use the `title` attribute.</li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.
           </li>
@@ -6198,10 +6198,10 @@
         <h4>Section and Grouping Element Accessible Description Computation</h4>
         <ol>
           <li>
-            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby">`aria-describedby`</a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>
-            Otherwise use the <code>title</code> attribute if it wasn't used as the <a class="termref">accessible name</a>.
+            Otherwise use the `title` attribute if it wasn't used as the <a class="termref">accessible name</a>.
           </li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible description</a>.
@@ -6211,15 +6211,17 @@
     </section>
     <section>
       <h3>Text Level Elements Not Listed Elsewhere</h3>
-      <p><a data-cite="html">`abbr`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-b-element"><code>b</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdi-element"><code>bdi</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"><code>bdo</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-br-element"><code>br</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-cite-element"><code>cite</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-code-element"><code>code</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-dfn-element"><code>dfn</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-em-element"><code>em</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-i-element"><code>i</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-kbd-element"><code>kbd</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-mark-element"><code>mark</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-q-element"><code>q</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rp-element"><code>rp</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rt-element"><code>rt</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-ruby-element"><code>ruby</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-s-element"><code>s</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-samp-element"><code>samp</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-small-element"><code>small</code></a>, <a>`strong`</a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sub</code> and <code>sup</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-time-element"><code>time</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-u-element"><code>u</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-var-element"><code>var</code></a>, <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-wbr-element"><code>wbr</code></a></p>
+      <p>
+        <a>`abbr`</a>, <a>`b`</a>, <a>`bdi`</a>, <a>`bdo`</a>, <a>`br`</a>, <a>`cite`</a>, <a>`code`</a>, <a>`dfn`</a>, <a>`em`</a>, <a>`i`</a>, <a>`kbd`</a>, <a>`mark`</a>, <a>`q`</a>, <a>`rp`</a>, <a>`rt`</a>, <a>`ruby`</a>, <a>`s`</a>, <a>`samp`</a>, <a>`small`</a>, <a>`strong`</a>, <a data-cite="HTML/text-level-semantics.html#the-sub-and-sup-elements">`sub` and `sup`</a>, <a>`time`</a>, <a>`u`</a>, <a>`var`</a>, <a>`wbr`</a>
+      </p>
       <section>
         <h4>Text Level Element Accessible Name Computation</h4>
         <ol>
           <li>
-            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label"><code>aria-label</code></a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"><code>aria-labelledby</code></a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label">`aria-label`</a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby">`aria-labelledby`</a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>Otherwise use the text element's subtree.</li>
-          <li>Otherwise use the <code>title</code> attribute.</li>
+          <li>Otherwise use the `title` attribute.</li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.
           </li>
@@ -6229,10 +6231,10 @@
         <h4>Text Level Element Accessible Description Computation</h4>
         <ol>
           <li>
-            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby"><code>aria-describedby</code></a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
+            If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-describedby">`aria-describedby`</a> attribute the <a class="termref">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
           <li>
-            Otherwise use the <code>title</code> attribute if it wasn't used as the <a class="termref">accessible name</a>.
+            Otherwise use the `title` attribute if it wasn't used as the <a class="termref">accessible name</a>.
           </li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible description</a>.
@@ -6244,27 +6246,37 @@
   <section class="informative">
     <h2>Accessible Feature Implementation Examples</h2>
     <section>
-      <h3><code>summary</code> and <code>details</code> Elements</h3>
+      <h3>`summary` and `details` Elements</h3>
       <section>
         <h4>Focus and Keyboard Interaction</h4>
-        <p>The <code>summary</code> element should be focusable by default.</p>
-        <p>The <code>details</code> element should not be focusable by default.</p>
-        <p>Pressing the spacebar or enter key when the <code>summary</code> element has focus will show the <code>details</code> element content if the content is hidden. If the <code>details</code> element content is showing and the <code>summary</code> element has focus, pressing the spacebar or enter key will hide the details element content.</p>
+        <p>The `summary` element should be focusable by default.</p>
+        <p>The `details` element should not be focusable by default.</p>
+        <p>
+          Pressing the <kbd>spacebar</kbd> or <kbd>enter</kbd> keys when the `summary` element has focus will show the `details` element content if the content was hidden. If the `details` element content was showing and the `summary` element has focus, pressing the <kbd>spacebar</kbd> or <kbd>enter</kbd> keys will hide the `details` element content.
+        </p>
       </section>
       <section>
         <h4>Role, Name, State and Property Mapping</h4>
-        <p>The <code>summary</code> element should be mapped to a disclosure triangle role in <a class="termref">accessibility APIs</a> that have such a role. For example the Mac <a class="termref">accessibility API</a> includes the <code>AXDisclosureTriangle</code> role. In <a class="termref">accessibility APIs</a> that do not have such a fine grained role, the <code>summary</code> element should be mapped to a <code>button</code> role. The role mapping table contains <a href="#el-summary">recommended mappings for the summary element</a>.</p>
-        <p>The default <a class="termref">accessible name</a> for the <code>summary</code> element is the text content of the <code>summary</code> element.</p>
+        <p>
+          The `summary` element should be mapped to a disclosure triangle role in <a class="termref">accessibility APIs</a> that have such a role. For example the Mac <a class="termref">accessibility API</a> includes the `AXDisclosureTriangle` role. In <a class="termref">accessibility APIs</a> that do not have such a fine grained role, the `summary` element should be mapped to a `button` role. The role mapping table contains <a href="#el-summary">recommended mappings for the summary element</a>.
+        </p>
+        <p>
+          The default <a class="termref">accessible name</a> for the `summary` element is the text content of the `summary` element.
+        </p>
+        <p>
+          When the `details` element content is hidden, the state of the content should be reflected by an accessible state or property.
+        </p>
+        <p>
+          <strong>Example 1:</strong> In the Mac <a class="termref">accessibility API</a> on the `summary` element (`AXDisclosureTriangle`), set `AXExpanded` property to `NO`.  When the `details` element content is shown, on the `summary` element (`AXDisclosureTriangle`), set the`AXExpanded` property to `YES`. The hidden and shown states of the `details` element content is reflected by the absence or presence of the <a href="#att-open-details">`open`</a> attribute.
+        </p>
 
-        <p>When the <code>details</code> element content is hidden, the state of the content should be reflected by an accessible state or property.</p>
-
-        <p><strong>Example 1:</strong> In the Mac <a class="termref">accessibility API</a> on the <code>summary</code> element (<code>AXDisclosureTriangle</code>), set <code>AXExpanded</code> property to <code>NO</code>.  When the <code>details</code> element content is shown, on the <code>summary</code> element (<code>AXDisclosureTriangle</code>), set the<code>AXExpanded</code> property to <code>YES</code>. The hidden and shown states of the <code>details</code> element content is reflected by the absence or presence of the <a href="#att-open-details"><code>open</code></a> attribute.</p>
-
-        <p><strong>Example 2:</strong> In the IA2 <a class="termref">accessibility API</a> on the <code>summary</code> element (<code>ROLE_SYSTEM_PUSHBUTTON</code>), set <code>STATE_SYSTEM_COLLAPSED</code>.  When the <code>details</code> element content is shown, on the <code>summary</code> element (<code>ROLE_SYSTEM_PUSHBUTTON</code>), set <code>STATE_SYSTEM_EXPANDED</code>. The hidden and shown states of the <code>details</code> element content is reflected by the absence or presence of the <a href="#att-open-details"><code>open</code></a> attribute.</p>
+        <p>
+          <strong>Example 2:</strong> In the IA2 <a class="termref">accessibility API</a> on the `summary` element (`ROLE_SYSTEM_PUSHBUTTON`), set `STATE_SYSTEM_COLLAPSED`.  When the `details` element content is shown, on the `summary` element (`ROLE_SYSTEM_PUSHBUTTON`), set `STATE_SYSTEM_EXPANDED`. The hidden and shown states of the `details` element content is reflected by the absence or presence of the <a href="#att-open-details">`open`</a> attribute.
+        </p>
       </section>
     </section>
     <section>
-      <h3>The <code>figure</code> and <code>figcaption</code> Elements</h3>
+      <h3>The `figure` and `figcaption` Elements</h3>
       <p class="ednote">to do</p>
     </section>
   </section>


### PR DESCRIPTION
update the resource linking from w3c HTML to WHATWG HTML, and use of markdown for code elements in the following sections:
5.14, 5.15, 5.16, 5.17, 6.1, 6.2

The following tasks have been completed:
 * [ x ] Confirmed there are no ReSpec errors or warnings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/217.html" title="Last updated on Jul 3, 2019, 12:14 PM UTC (24e5ca8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/217/3b92a0b...24e5ca8.html" title="Last updated on Jul 3, 2019, 12:14 PM UTC (24e5ca8)">Diff</a>