### PR TITLE
table header was pointing to ARIA 1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
       		<thead>
       			<tr>
       				<th>Element</th>
-      				<th>[[[WAI-ARIA]]]</th>
+      				<th>[[wai-aria-1.1]]</th>
       				<th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
       				<th><a href="https://developer.gnome.org/atk/stable/">ATK</a></th>


### PR DESCRIPTION
changed as latest REc is ARIA 1.1


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/223.html" title="Last updated on Jul 15, 2019, 10:11 AM UTC (af9002c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/223/24f3ea1...af9002c.html" title="Last updated on Jul 15, 2019, 10:11 AM UTC (af9002c)">Diff</a>