### PR TITLE
Update mapping for ATK summary element

### DIFF
--- a/index.html
+++ b/index.html
@@ -3264,45 +3264,48 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-summary">
-                <th><a data-cite="HTML">`summary`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role: </span><code>ROLE_SYSTEM_PUSHBUTTON</code>
-                  </div>
-                  <div class="states">
-                    <span class="type">States: </span><code>STATE_SYSTEM_EXPANDED</code> / <code>STATE_SYSTEM_COLLAPSED</code>
-                  </div>
-                  <div class="actions">
-                    <span class="type">Actions: </span><code>expand</code> / <code>collapse</code>
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type: </span><code>Button</code>
-                    </div>
-                    <div class="ctrlpattern">
-                        <span class="type">Control Pattern: </span><code>ExpandCollapse</code>
-                    </div>
-                </td>
                 <td class="atk">
                   <div class="role">
                     <span class="type">Role: </span>
                     <code>ATK_ROLE_PUSHBUTTON</code>
                   </div>
                 </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole: </span><code>AXDisclosureTriangle</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole: </span><code>(nil)</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription: </span><code>"disclosure triangle"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`summary`</a>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_PUSHBUTTON`
+                </div>
+                <div class="states">
+                  <span class="type">States:</span>
+                  `STATE_SYSTEM_EXPANDED` / `STATE_SYSTEM_COLLAPSED`
+                </div>
+                <div class="actions">
+                  <span class="type">Actions:</span> `expand` / `collapse`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Button`
+                </div>
+                <div class="ctrlpattern">
+                  <span class="type">Control Pattern:</span> `ExpandCollapse`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXDisclosureTriangle`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"disclosure triangle"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-sup">
                 <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sup</code></a></th>
@@ -3351,22 +3354,22 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-table">
-                <th><a data-cite="HTML">`table`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-table"><code>table</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`table`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-table"><code>table</code></a> role</td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-tbody">
-                <th><a data-cite="HTML">`tbody`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`tbody`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-td">
                 <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-td-element"><code>td</code></a> (ancestor <a href="https://www.w3.org/TR/html/tabular-data.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-table"><code>table</code></a> role)</th>
@@ -6273,7 +6276,7 @@
           When the `details` element content is hidden, the state of the content should be reflected by an accessible state or property.
         </p>
         <p>
-          <strong>Example 1:</strong> In the Mac <a class="termref">accessibility API</a> on the `summary` element (`AXDisclosureTriangle`), set `AXExpanded` property to `NO`.  When the `details` element content is shown, on the `summary` element (`AXDisclosureTriangle`), set the`AXExpanded` property to `YES`. The hidden and shown states of the `details` element content is reflected by the absence or presence of the <a href="#att-open-details">`open`</a> attribute.
+          <strong>Example 1:</strong> In the Mac <a class="termref">accessibility API</a> on the `summary` element (`AXDisclosureTriangle`), set `AXExpanded` property to `NO`.  When the `details` element content is shown, on the `summary` element (`AXDisclosureTriangle`), set the `AXExpanded` property to `YES`. The hidden and shown states of the `details` element content is reflected by the absence or presence of the <a href="#att-open-details">`open`</a> attribute.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3264,12 +3264,6 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-summary">
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span>
-                    <code>ATK_ROLE_PUSHBUTTON</code>
-                  </div>
-                </td>
               <th>
                 <a data-cite="HTML">`summary`</a>
               </th>
@@ -3292,6 +3286,11 @@
                 </div>
                 <div class="ctrlpattern">
                   <span class="type">Control Pattern:</span> `ExpandCollapse`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_TOGGLE_BUTTON`
                 </div>
               </td>
               <td class="ax">

--- a/index.html
+++ b/index.html
@@ -1026,6 +1026,9 @@
                 <div class="role">
                   <span class="type">Role:</span> `ATK_ROLE_PANEL`
                 </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `ATK_RELATION_DETAILS_FOR`
+                </div>
               </td>
               <td class="ax">
                 <div class="role">
@@ -3291,6 +3294,9 @@
               <td class="atk">
                 <div class="role">
                   <span class="type">Role:</span> `ROLE_TOGGLE_BUTTON`
+                </div>
+                <div class="relations">
+                  <span class="type">Relations:</span> `ATK_RELATION_DETAILS`
                 </div>
               </td>
               <td class="ax">
@@ -6295,7 +6301,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
-            <li>22-July-2019: Update ATK mapping for `summary` element. See <a href="https://github.com/w3c/html-aam/issues/142">GitHub issue #142</a>.</li>
+            <li>23-August-2019: Update ATK mappings for `summary` and `details` elements. See <a href="https://github.com/w3c/html-aam/issues/142">GitHub issue #142</a> and <a href="https://github.com/w3c/html-aam/issues/147">GitHub issue #147</a>.</li>
             <li>10-July-2019: Further updated mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/pull/219">GitHub pull request #219</a>.</li>
             <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>
             <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>

--- a/index.html
+++ b/index.html
@@ -6295,6 +6295,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
+            <li>22-July-2019: Update ATK mapping for `summary` element. See <a href="https://github.com/w3c/html-aam/issues/142">GitHub issue #142</a>.</li>
             <li>10-July-2019: Further updated mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/pull/219">GitHub pull request #219</a>.</li>
             <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>
             <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>


### PR DESCRIPTION
Closes #142 and closes #147 

changes ATK mapping from:
`ROLE_PUSH_BUTTON` to `ROLE_TOGGLE_BUTTON` for `summary` element.

The following tasks have been completed:
[x] Confirmed there are no ReSpec/BikeShed errors or warnings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/224.html" title="Last updated on Sep 18, 2019, 3:50 PM UTC (e62fa9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/224/63ac0c5...e62fa9e.html" title="Last updated on Sep 18, 2019, 3:50 PM UTC (e62fa9e)">Diff</a>