### PR TITLE
include acknowledgements as a fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -6349,20 +6349,7 @@
           </ul>
         </section>
       </section>
-    <section class="appendix informative" id="acknowledgements">
-  		<h3>Acknowledgments</h3>
-  		<p>The following people contributed to the development of this document.</p>
-		  <section class="section" id="ack_group">
-		    <h4>Participants active in the HTML Accessibility Task Force active at the time of publication</h4>
-        <ul>
-				  <li>@@</li>
-        </ul>
-  		</section>
-		  <section class="section" id="ack_funders">
-  			<h4>Enabling funders</h4>
-  			<p>This publication has been funded in part with U.S. Federal funds from the Department of Education, National Institute on Disability, Independent Living, and Rehabilitation Research (NIDILRR), initially under contract number ED-OSE-10-C-0067 and currently under contract number HHSP23301500054C. The content of this publication does not necessarily reflect the views or policies of the U.S. Department of Education, nor does mention of trade names, commercial products, or organizations imply endorsement by the U.S. Government.</p>
-		  </section>
-    </section>
+      <div data-include="sections/acknowledgements.frag" data-include-replace="true"></div>
   </section>
 </body>
 </html>

--- a/sections/acknowledgements.frag
+++ b/sections/acknowledgements.frag
@@ -1,0 +1,16 @@
+<section id="acknowledgements" class="appendix informative">
+  <h3>Acknowledgments</h3>
+  <p>The following people contributed to the development of this document.</p>
+  <section class="section" id="ack_group">
+    <h4>Participants active in the HTML Accessibility Task Force active at the time of publication</h4>
+    <ul>
+      <li>@@</li>
+    </ul>
+  </section>
+  <section class="section" id="ack_funders">
+    <h4>Enabling funders</h4>
+    <p>
+      This publication has been funded in part with U.S. Federal funds from the Department of Education, National Institute on Disability, Independent Living, and Rehabilitation Research (NIDILRR), initially under contract number ED-OSE-10-C-0067 and currently under contract number HHSP23301500054C. The content of this publication does not necessarily reflect the views or policies of the U.S. Department of Education, nor does mention of trade names, commercial products, or organizations imply endorsement by the U.S. Government.
+    </p>
+  </section>
+</section>


### PR DESCRIPTION
I would personally like to (lightly) utilize refspec's [data include replace](https://github.com/w3c/respec/wiki/data-include-replace) feature to separate out some sections of the HTML AAM spec into fragment files.  

I'd like to start with the appendices, but pending potential merge conflicts with other open PRs, this PR only fragments out the acknowledgements section.

@stevefaulkner any objections to doing this?

If not, I'll add-on to this PR with a note in the README on how to run a quick localhost on mac and PC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/228.html" title="Last updated on Jul 24, 2019, 3:52 AM UTC (9c6a24e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/228/f7c394a...9c6a24e.html" title="Last updated on Jul 24, 2019, 3:52 AM UTC (9c6a24e)">Diff</a>