### PR TITLE
Unify <mark>'s UIA LocalizedControlType and AX AXRoleDescription

### DIFF
--- a/index.html
+++ b/index.html
@@ -2483,7 +2483,7 @@
                   <span class="type">Control Type: </span><code>Text</code>
                 </div>
                 <div class="ctrltype">
-                  <span class="type">Localized Control Type: </span><code>"mark"</code>
+                  <span class="type">Localized Control Type: </span><code>"highlight"</code>
                 </div>
               </td>
               <td class="atk"><div class="general">
@@ -2509,7 +2509,7 @@
                   <span class="type">AXSubrole: </span><code>(nil)</code>
                 </div>
                 <div class="roledesc">
-                  <span class="type">AXRoleDescription: </span><code>"highlighted content"</code>
+                  <span class="type">AXRoleDescription: </span><code>"highlight"</code>
                 </div>
               </td>
               <td class="comments"></td>


### PR DESCRIPTION
Per https://w3c.github.io/html-aam/#el-mark, the UIA LocalizedControlType for `<mark>` is "mark" while the AXRoleDescription is "highlighted content".  There is no good reason for these values to be different; this adds complexity for implementers and creates confusion for users when moving across platforms.  Furthermore, "mark" is a confusing name for non-programmers, and "highlighted content" is unnecessary verbose.

This change switches both role descriptions to "highlight", removing the inconsistency and improving upon both existing names.

Closes #236 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=201958)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=996459)
* [x] Gecko (none yet)

CC: @aleventhal @cookiecrook  @boggydigital


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dandclark/html-aam/pull/235.html" title="Last updated on Sep 19, 2019, 1:09 AM UTC (6b2854d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/235/f7c394a...dandclark:6b2854d.html" title="Last updated on Sep 19, 2019, 1:09 AM UTC (6b2854d)">Diff</a>