### PR TITLE
updated guidance regarding whitespace and element naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -5709,10 +5709,18 @@
   </section>
   <section class="normative">
     <h2>Accessible Name and Description Computation</h2>
-    <p>The terms <a class="termref">accessible name</a> and <a class="termref">accessible description</a> are properties provided in all <a class="termref">accessibility APIs</a>. The name of the properties may differ across APIs but they serve the same function: as a container for a short (name) or longer (description) string of text. </p>
+    <p>The terms <a class="termref">accessible name</a> and <a class="termref">accessible description</a> are properties provided in all <a class="termref">accessibility APIs</a>. The name of the properties may differ across APIs but they serve the same function: as a container for a short (name) or longer (description) string of text.</p>
     <p>The <a href="#mapping_additional_nd_te" class="accname">text alternative computation</a> is used to generate both the <a class="termref">accessible name</a> and <a class="termref">accessible description</a>. There are different rules provided for several different types of <a class="termref" data-lt="element">elements</a>, <a class="termref" data-lt="node">nodes</a>, and combinations of markup.</p>
+    <p>Certain attributes such as `aria-label`, `aria-labelledby`, `alt`, `title`, and `aria-describedby`, can contribute to the accessible name or description of an element if their returned value is not the empty string, nor, when trimmed of white space, is not the empty string. For instances where an attribute's value returns the empty string, user agents MUST move onto the next step in the name or description algorithm.</p>
+
+    <div class="note">
+      <p>For example, the following graphic has `alt` and a `title` attributes, however the `alt` contains only whitespace. In this instance, the `alt` should have its whitespace trimmed and be ignored due to it returning the empty string. User agents would then look to the `title` to provide the graphic its accessible name.</p>
+
+      <pre><code>&lt;img src="moon.jpg" alt=" " title="A waning crescent Moon"></code></pre>
+    </div>
+
     <section>
-      <h3><code>input type="text"</code>, <code>input type="password"</code>,<code> input type="search"</code>,<code> input type="tel"</code>, <code>input type="url"</code> and <code>textarea</code> Element</h3>
+      <h3><code>input type="text"</code>, <code>input type="password"</code>,<code> input type="search"</code>,<code> input type="tel"</code>, <code>input type="email"</code>, <code>input type="url"</code> and <code>textarea</code> Element</h3>
       <section>
         <h4><code>input type="text"</code>, <code>input type="password"</code>,<code> input type="search"</code>,<code> input type="tel"</code>, <code>input type="email"</code>, <code>input type="url"</code> and <code>textarea</code> Element Accessible Name Computation</h4>
         <ol>

--- a/index.html
+++ b/index.html
@@ -6477,9 +6477,11 @@
     <p>Certain attributes such as `aria-label`, `aria-labelledby`, `alt`, `title`, and `aria-describedby`, can contribute to the accessible name or description of an element if their returned value (once white space is trimmed) is not the empty string. For instances where an attribute's value returns the empty string, user agents MUST move on to the next step in the name or description algorithm.</p>
 
     <div class="note">
-      <p>For example, the following graphic has `alt` and a `title` attributes, however the `alt` contains only whitespace. In this instance, the `alt` has its whitespace trimmed and is ignored due to returning the empty string. User agents then use the `title` to provide the graphic its accessible name.</p>
+      <p>For example, the following graphic has `aria-label` and a `alt` attributes, however the `aria-label` contains only whitespace. 
+        In this instance, the `aria-label` has its whitespace trimmed and is ignored due to returning the empty string. 
+        User agents then use the `alt` to provide the graphic its accessible name.</p>
 
-      <pre><code>&lt;img src="moon.jpg" alt=" " title="A waning crescent Moon"></code></pre>
+      <pre><code>&lt;img src="moon.jpg" aria-label=" " alt="A waning crescent Moon"></code></pre>
     </div>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -5711,10 +5711,10 @@
     <h2>Accessible Name and Description Computation</h2>
     <p>The terms <a class="termref">accessible name</a> and <a class="termref">accessible description</a> are properties provided in all <a class="termref">accessibility APIs</a>. The name of the properties may differ across APIs but they serve the same function: as a container for a short (name) or longer (description) string of text.</p>
     <p>The <a href="#mapping_additional_nd_te" class="accname">text alternative computation</a> is used to generate both the <a class="termref">accessible name</a> and <a class="termref">accessible description</a>. There are different rules provided for several different types of <a class="termref" data-lt="element">elements</a>, <a class="termref" data-lt="node">nodes</a>, and combinations of markup.</p>
-    <p>Certain attributes such as `aria-label`, `aria-labelledby`, `alt`, `title`, and `aria-describedby`, can contribute to the accessible name or description of an element if their returned value is not the empty string, nor, when trimmed of white space, is not the empty string. For instances where an attribute's value returns the empty string, user agents MUST move onto the next step in the name or description algorithm.</p>
+    <p>Certain attributes such as `aria-label`, `aria-labelledby`, `alt`, `title`, and `aria-describedby`, can contribute to the accessible name or description of an element if their returned value (once white space is trimmed) is not the empty string. For instances where an attribute's value returns the empty string, user agents MUST move on to the next step in the name or description algorithm.</p>
 
     <div class="note">
-      <p>For example, the following graphic has `alt` and a `title` attributes, however the `alt` contains only whitespace. In this instance, the `alt` should have its whitespace trimmed and be ignored due to it returning the empty string. User agents would then look to the `title` to provide the graphic its accessible name.</p>
+      <p>For example, the following graphic has `alt` and a `title` attributes, however the `alt` contains only whitespace. In this instance, the `alt` has its whitespace trimmed and is ignored due to returning the empty string. User agents then use the `title` to provide the graphic its accessible name.</p>
 
       <pre><code>&lt;img src="moon.jpg" alt=" " title="A waning crescent Moon"></code></pre>
     </div>

--- a/index.html
+++ b/index.html
@@ -6474,7 +6474,12 @@
     <h2>Accessible Name and Description Computation</h2>
     <p>The terms <a class="termref">accessible name</a> and <a class="termref">accessible description</a> are properties provided in all <a class="termref">accessibility APIs</a>. The name of the properties may differ across APIs but they serve the same function: as a container for a short (name) or longer (description) string of text.</p>
     <p>The <a href="#mapping_additional_nd_te" class="accname">text alternative computation</a> is used to generate both the <a class="termref">accessible name</a> and <a class="termref">accessible description</a>. There are different rules provided for several different types of <a class="termref" data-lt="element">elements</a>, <a class="termref" data-lt="node">nodes</a>, and combinations of markup.</p>
-    <p>Certain attributes such as `aria-label`, `aria-labelledby`, `alt`, `title`, and `aria-describedby`, can contribute to the accessible name or description of an element if their returned value (once white space is trimmed) is not the empty string. For instances where an attribute's value returns the empty string, user agents MUST move on to the next step in the name or description algorithm.</p>
+    <p>
+      Certain attributes such as `aria-label`, `aria-labelledby`, `alt`, `title`, and `aria-describedby`, can contribute to the accessible name or 
+      description of an element if their returned value (once <a href="https://infra.spec.whatwg.org/#ascii-whitespace">whitespace</a> is trimmed) 
+      is not the empty string. For instances where an attribute's value returns the empty string, user agents MUST move on to the next step in the 
+      name or description algorithm.
+    </p>
 
     <div class="note">
       <p>For example, the following graphic has `aria-label` and a `alt` attributes, however the `aria-label` contains only whitespace. 


### PR DESCRIPTION
Closes #238 

- [x] Confirmed there are no ReSpec/BikeShed errors or warnings.

Test cases showing current browser support/behavior by some screen readers:
https://scottaohara.github.io/tests/html-img/whitespace.html

Implementation commitment:

 * [ ] WebKit (...)
 * [ ] Chromium (...)
 * [ ] Gecko (...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/239.html" title="Last updated on Nov 20, 2021, 7:43 PM UTC (8bf8539)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/239/820b92f...8bf8539.html" title="Last updated on Nov 20, 2021, 7:43 PM UTC (8bf8539)">Diff</a>