### PR TITLE
editorial: updates to attrs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3660,8 +3660,9 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-allowfullscreen">
-                <th><code>allowfullscreen</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-iframe-allowfullscreen"><code>iframe</code></a></td>
+                <th>`allowfullscreen`</th>
+                <td class="elements"><a data-cite=
+            "html/iframe-embed-object.html#attr-iframe-allowfullscreen">`iframe`</a></td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
@@ -3701,7 +3702,7 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-autocomplete-form">
-                <th><code>autocomplete</code> "on|off"</th>
+                <th>`autocomplete` "on|off"</th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-autocompleteelements-autocomplete"><code>form</code></a></td>
                 <td class="aria"><p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code></a></p>
               <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p></td>
@@ -3744,18 +3745,24 @@
                 <td class="comments">If the element includes both <code>autocomplete</code> and <code>aria-autocomplete</code> attributes with valid values, User Agents MUST expose only the <code>autocomplete</code> attribute value. </td>
             </tr>
             <tr tabindex="-1" id="att-autofocus">
-                <th><code>autofocus</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-autofocus"><code>button</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-autofocus"><code>input</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-autofocus"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-autofocus"><code>textarea</code></a></td>
-                <td class="aria">Not mapped - <a class="core-mapping" href="#ariaFlowto"><code>aria-flowto</code></a>?</td>
+                <th>`autofocus`</th>
+                <td class="elements">
+                  <a data-cite="html/interaction.html#attr-fe-autofocus">HTML elements</a>
+                </td>
+                <td class="aria">Not mapped</td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
                 <td class="atk"><div class="general">Not mapped</div></td>
                 <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+                <td class="comments">
+                  Similar to <a class="core-mapping" href="#ariaFlowto"><code>aria-flowto</code></a>.
+                </td>
             </tr>
             <tr tabindex="-1" id="att-autoplay">
                 <th><code>autoplay</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-autoplay"><code>audio</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-autoplay"><code>video</code></a></td>
+                <td class="elements">
+                  <a data-cite="html/media.html#attr-media-autoplay">`audio` and `video`</a>
+                </td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
@@ -3764,24 +3771,16 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-charset-meta">
-                <th><code>charset</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-meta-charset"><code>meta</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-charset-script">
-                <th><code>charset</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-charset"><code>script</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`charset`</th>
+              <td class="elements">
+                <a data-cite="html/semantics.html#attr-meta-charset">`meta`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-checked">
               <th>


### PR DESCRIPTION
update links to HTML spec for:
* `allowfullscreen`
* `autofocus` (change from individual controls to HTML elements)
* `autoplay` same URL so combine `autio` and `video` into 1 link.
* `charset`

Remove `script[charset]` as it is obsolete in HTML.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/241.html" title="Last updated on Sep 13, 2019, 3:08 AM UTC (4e2577b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/241/733ebc6...4e2577b.html" title="Last updated on Sep 13, 2019, 3:08 AM UTC (4e2577b)">Diff</a>