### PR TITLE
editorial: updates to attrs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3691,6 +3691,19 @@
                 <td class="ax"><code>AXDescription: &lt;value&gt;</code></td>
                 <td class="comments"></td>
             </tr>
+            <tr tabindex="-1" id="att-as">
+                <th>`as`</th>
+                <td class="elements">
+                  <a data-cite=
+            "html/semantics.html#attr-link-as">`link`</a>
+                </td>
+                <td class="aria"><div class="general">Not mapped</div></td>
+                <td class="ia2"><div class="general">Not mapped</div></td>
+                <td class="uia"><div class="general">Not mapped</div></td>
+                <td class="atk"><div class="general">Not mapped</div></td>
+                <td class="ax"><div class="general">Not mapped</div></td>
+                <td class="comments"></td>
+            </tr>
             <tr tabindex="-1" id="att-async">
                 <th><code>async</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-async"><code>script</code></a></td>
@@ -3823,250 +3836,301 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-cite">
-                <th><code>cite</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/grouping-content.html#element-attrdef-blockquote-cite"><code>blockquote</code></a>; <a href="https://www.w3.org/TR/html/edits.html#element-attrdef-edits-cite"><code>del</code></a>; <a href="https://www.w3.org/TR/html/edits.html#element-attrdef-edits-cite"><code>ins</code></a>; <a href="https://www.w3.org/TR/html/textlevel-semantics.html#element-attrdef-q-cite"><code>q</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><code>AXURL: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`cite`</th>
+              <td class="elements">
+                <a data-cite="html/grouping-content.html#attr-blockquote-cite">`blockquote`</a>;
+                <a data-cite="html/edits.html#attr-mod-cite">`del` and `ins`</a>;
+                <a data-cite="html/text-level-semantics.html#attr-q-cite">`q`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><code>AXURL: &lt;value&gt;</code></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-class">
-                <th><code>class</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/dom.html#element-attrdef-global-class">HTML elements</a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`class`</th>
+              <td class="elements">
+                <a data-cite="html/dom.html#classes">HTML elements</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-class">
+              <th>`color`</th>
+              <td class="elements">
+                <a data-cite="html/semantics.html#attr-link-color">`link`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-cols">
-                <th><code>cols</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-textarea-cols"><code>textarea</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><code>AXRangeForLine: &lt;value&gt;</code></td>
-                <td class="comments"><div class="general">Not mapped</div></td>
+              <th>`cols`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-textarea-cols">`textarea`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax">`AXRangeForLine: &lt;value&gt;`</td>
+              <td class="comments"><div class="general">Not mapped</div></td>
             </tr>
             <tr tabindex="-1" id="att-colspan">
-                <th><code>colspan</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/tabular-data.html#element-attrdef-tablecells-colspan"><code>td</code></a>; <a href="https://www.w3.org/TR/html/tabular-data.html#element-attrdef-tablecells-colspan"><code>th</code></a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaColSpan"><code>aria-colspan</code></a></td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>`colspan`</th>
+              <td class="elements">
+                <a data-cite="html/tables.html#attr-tdth-colspan">`td` and `th`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaColSpan">`aria-colspan`</a></td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-content">
-                <th><code>content</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-meta-content"><code>meta</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><code>content</code></th>
+              <td class="elements"><a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-meta-content"><code>meta</code></a></td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-contenteditable">
                 <th><code>contenteditable</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-contenteditable">HTML elements</a></td>
+                <td class="elements">
+                  <a data-cite="html/interaction.html#attr-contenteditable">HTML elements</a>
+                </td>
                 <td class="aria">?</td>
                 <td class="ia2">
                   <div class="states">
-                    <span class="type">States: </span>
-                    <code>IA2_STATE_EDITABLE</code> on this and every nested text accessible object
+                    <span class="type">States:</span>
+                    `IA2_STATE_EDITABLE` on this and every nested text accessible object
                   </div>
                   <div class="interfaces">
-                    <span class="type">Interfaces: </span>
-                    <code>IAccessibleEditableText</code> on this and every nested text accessible object
+                    <span class="type">Interfaces:</span>
+                    `IAccessibleEditableText` on this and every nested text accessible object
                   </div>
                 </td>
                 <td class="uia">
                   <div class="ctrltype">
-                        <span class="type">Control Pattern: </span><code>TextEdit</code>
+                    <span class="type">Control Pattern:</span> `TextEdit`
                   </div>
                 </td>
                 <td class="atk">
                   <div class="states">
-                    <span class="type">States: </span>
-                    <code>ATK_STATE_EDITABLE</code> on this and every nested text accessible object
+                    <span class="type">States:</span>
+                    `ATK_STATE_EDITABLE` on this and every nested text accessible object
                   </div>
                   <div class="interfaces">
-                    <span class="type">Interfaces: </span>
-                    <code>AtkEditableText</code> on this and every nested text accessible object
-                  </div>
-                </td>
-                <td class="ax"><span class="type">Role: </span><a href="#el-textarea">AXtextArea</a>                  <div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments">If the element has the <code>contenteditable</code> attribute  and <code>aria-readonly=&quot;true</code>&quot;, User Agents MUST expose only the <code>contenteditable</code> state.</td>
-            </tr>
-            <tr tabindex="-1" id="att-contextmenu">
-                <th><code>contextmenu</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-global-contextmenu">HTML elements</a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaHaspopupTrue"><code>aria-haspopup</code></a>="true"</td>
-                <td class="ia2">
-                  <div class="general">
-                    Linked menu is available in browser's context menu on the element
-                  </div>
-                </td>
-                <td class="uia">Expose state of the pop-up activities in the <code>ExpandCollapseState</code> property in the <code>ExpandCollapse</code> control pattern.</td>
-                <td class="atk">
-                  <div class="general">
-                    Linked menu is available in browser's context menu on the element
+                    <span class="type">Interfaces:</span>
+                    `AtkEditableText` on this and every nested text accessible object
                   </div>
                 </td>
                 <td class="ax">
-                  <div class="actions">
-                    <span class="type">Actions: </span><code>AXShowMenu</code>; <code>AXPress</code>
-                  </div>
+                  <span class="type">Role:</span>
+                  <a href="#el-textarea">AXtextArea</a>
+                  <div class="general">Use WAI-ARIA mapping</div>
                 </td>
-                <td class="comments"></td>
+                <td class="comments">
+                  If the element has the `contenteditable` attribute  and `aria-readonly="true"`, User Agents MUST expose only the `contenteditable` state.
+                </td>
             </tr>
             <tr tabindex="-1" id="att-controls">
-                <th><code>controls</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-mediaelements-controls"><code>audio</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-mediaelements-controls"><code>video</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax">Controls exposed as <code>AXToolbar</code></td>
-                <td class="comments"></td>
+              <th>`controls`</th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax">Controls exposed as `AXToolbar`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-coords">
-                <th><code>coords</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-area-coords"><code>area</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="general">
-                    Defines an accessible object's dimensions (<code>IAccessible::accLocation</code>)
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    Defines an accessible object's dimensions (<code>BoundingRectangle</code>)
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    Defines an accessible object's dimensions, exposed via
-                    <code>atk_component_get_position</code> and <code>atk_component_get_size</code>
-                  </div>
-                </td>
-                <td class="ax"><span class="general">Defines an accessible object's dimensions, exposed via </span> <code>Frame</code> property</td>
-                <td class="comments"></td>
+              <th>`coords`</th>
+              <td class="elements">
+                <a data-cite="html/image-maps.html#attr-area-coords">`area`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="general">
+                  Defines an accessible object's dimensions (`IAccessible::accLocation`)
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  Defines an accessible object's dimensions (`BoundingRectangle`)
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  Defines an accessible object's dimensions, exposed via `atk_component_get_position` and `atk_component_get_size`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="general">
+                  Defines an accessible object's dimensions, exposed via `Frame` property
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-crossorigin">
-                <th><code>crossorigin</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-crossorigin"><code>audio</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-img-crossorigin"><code>img</code></a>; <a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-link-crossorigin"><code>link</code></a>; <a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-crossorigin"><code>script</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-crossorigin"><code>video</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`crossorigin`</th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-media-crossorigin">`audio`</a>;
+                <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>;
+                <a data-cite="html/semantics.html#attr-link-crossorigin">`link`</a>;
+                <a data-cite="html/scripting.html#attr-script-crossorigin">`script`</a>;
+                <a data-cite="html/media.html#attr-media-crossorigin">`video`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-data">
-                <th><code>data</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-object-data"><code>object</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`data`</th>
+              <td class="elements">
+                <a data-cite="html/iframe-embed-object.html#attr-object-data">`object`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-datetime-delins">
-                <th><code>datetime</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/edits.html#element-attrdef-edits-datetime"><code>del</code></a>; <a href="https://www.w3.org/TR/html/edits.html#element-attrdef-edits-datetime"><code>ins</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="objattrs">
-                    <span class="type">Object attributes:</span> <code>datetime: &lt;value&gt;</code>
-                  </div>
-                </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk">
-                  <div class="objattrs">
-                    <span class="type">Object attributes:</span> <code>datetime: &lt;value&gt;</code>
-                  </div>
-                </td>
-                <td class="ax"><code>AXDateTimeValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`datetime`</th>
+              <td class="elements">
+                <a data-cite="html/edits.html#attr-mod-datetime">`del` and `ins`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk">
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="ax">`AXDateTimeValue: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-datetime-time">
-                <th><code>datetime</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/textlevel-semantics.html#element-attrdef-time-datetime"><code>time</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                 <div class="objattrs">
-                    <span class="type">Object attributes:</span> <code>datetime: &lt;value&gt;</code></div>
-                </td>
-                <td class="uia">
-                  <div class="properties">
-                    <span class="type">Properties: </span><code>FullDescription: &lt;value&gt;</code></div>
-                </td>
-                <td class="atk">
-                 <div class="objattrs">
-                    <span class="type">Object attributes:</span> <code>datetime: &lt;value&gt;</code></div>
-                </td>
-                <td class="ax"><code>AXDateTimeValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`datetime`</th>
+              <td class="elements">
+                <a data-cite="html/text-level-semantics.html#attr-time-datetime">`time`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="properties">
+                  <span class="type">Properties:</span> `FullDescription: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="ax">`AXDateTimeValue: &lt;value&gt;`</td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-decoding">
+              <th>`default`</th>
+              <td class="elements">
+                <a data-cite="html/embedded-content.html#attr-img-decoding">`img`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">???</div></td>
+              <td class="uia"><div class="general">???</div></td>
+              <td class="atk"><div class="general">???</div></td>
+              <td class="ax"><div class="general">???</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-default">
-                <th><code>default</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-track-default"><code>track</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`default`</th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-track-default">`track`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-defer">
-                <th><code>defer</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-defer"><code>script</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`defer`</th>
+              <td class="elements">
+                <a data-cite="html/scripting.html#attr-script-defer">`script`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-dir">
-                <th><code>dir</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/dom.html#element-attrdef-global-dir">HTML elements</a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="general">
-                    Exposed as "writing-mode" text attribute on the text container.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    Exposed by <code>TextFlowDirections</code> attribute of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    Exposed as "writing-mode" text attribute on the text container.
-                  </div>
-                </td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`dir`</th>
+              <td class="elements">
+                <a data-cite="html/dom.html#the-dir-attribute">HTML elements</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as "writing-mode" text attribute on the text container.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  Exposed by `TextFlowDirections` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as "writing-mode" text attribute on the text container.
+                </div>
+              </td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-dirname">
-                <th><code>dirname</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-dirname"><code>input</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-dirname"><code>textarea</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`dirname`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-dirname">`input` and
+                `textarea`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-disabled">
                 <th><code>disabled</code></th>
@@ -4114,16 +4178,6 @@
                     draggable:true
                   </div>
                 </td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-dropzone">
-                <th><code>dropzone</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-dropzone" title="attr-dropzone">HTML elements</a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>


### PR DESCRIPTION
update attribute links to HTML spec for:
* `cite`
* `class`
* `cols`
* `colspan`
* `content`
* `contenteditable`
* `controls`
* `coords`
* `crossorigin`
* `data`
* `datetime`
* `default`
* `defer`
* `dir`
* `dirname`

add attributes:
* `as`
* `color`

remove obsolete attributes:
* `contextmenu`
* `dropzone`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/242.html" title="Last updated on Sep 14, 2019, 2:20 AM UTC (3dfc1db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/242/9b44293...3dfc1db.html" title="Last updated on Sep 14, 2019, 2:20 AM UTC (3dfc1db)">Diff</a>