### PR TITLE
Editorial: attribute updates pt3

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
       <p>For HTML elements or attributes with default WAI-ARIA semantics, user agents MUST conform to <a class="core-mapping" href="#mapping_nodirect">Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</a> in the [[core-aam-1.2]].</p>
       <section>
         <h4>Other Accessibility Implementations</h4>
-        <section data-cite="HTML">
+        <section>
           <h5>Use of MSAA VARIANT by Some <a class="termref">User Agents</a></h5>
           <p>In MSAA, the value of an <a>accessible object</a>'s <a href="https://docs.microsoft.com/en-us/windows/desktop/WinAuto/role-property">Role property</a> is retrieved with the <a href="https://docs.microsoft.com/en-us/windows/desktop/api/oleacc/nf-oleacc-iaccessible-get_accrole">IAccessible::get_accRole method</a>. This method returns a <a href="https://docs.microsoft.com/en-us/windows/desktop/api/oaidl/ns-oaidl-tagvariant">VARIANT</a> that is limited to a finite number of <a href="https://docs.microsoft.com/en-us/windows/desktop/WinAuto/object-roles">integer role constants</a> insufficient for describing the role of every HTML element, especially new elements introduced by HTML. To address this limitation, some user agents, e.g., Firefox and Chrome in cooperation with some screen readers, have elected to expose certain roles by returning a string value (<a href="https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr">BSTR</a>) in that VARIANT in a way that is not described by the MSAA specification.</p>
           <p>For example, Firefox returns the element's tag name as a BSTR for the following: <a>`abbr`</a>, <a>`address`</a>, <a>`aside`</a>, <a>`blockquote`</a>, <a>`canvas`</a>, <a>`caption`</a>, <a>`dd`</a>, <a>`div`</a>, <a>`figcaption`</a>, <a>`footer`</a>, <a>`form`</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`–`h6`</a>, <a>`header`</a>, <a>`iframe`</a>, <a data-cite="html/input.html#file-upload-state-(type=file)">`input type="file"`</a>, <a>`main`</a>, <a>`menu`</a>, <a>`nav`</a>, <a>`output`</a>, <a>`p`</a>, <a>`pre`</a>, <a>`q`</a>, <a>`section`</a>, <a>`time`</a>.</p>
@@ -212,7 +212,7 @@
         </li>
         <li><strong>UIA:</strong>
           <ul>
-            <li>When a <a href="https://www.w3.org/TR/html/sec-forms.html#labelable-element">labelable element</a> is referenced by a `label` element's `for` attribute, or a descendant of a `label` element, the labelable element's UIA `LabeledBy` property points to the UIA element for the `label` element.</li>
+            <li>When a <a data-cite="html/forms.html#category-label">labelable element</a> is referenced by a `label` element's `for` attribute, or a descendant of a `label` element, the labelable element's UIA `LabeledBy` property points to the UIA element for the `label` element.</li>
             <li>Elements mapped to the `Text` Control Type are not generally represented as <a class="termref" data-lt="accessible object">accessible objects</a> in the <a class="termref">accessibility tree</a>, but are just part of the `Text` Control Pattern implemented for the whole HTML document. However, if they have any `aria-` attributes or an explicit `tabindex` specified, elements mapped to the `Text` Control Type will be represented as <a class="termref" data-lt="accessible object">accessible objects</a> in the <a class="termref">accessibility tree</a>.</li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -3862,7 +3862,7 @@
                 `checked` (if present)
               </th>
               <td class="elements">
-                <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked">`input`</a>
+                <a data-cite="html/input.html#attr-input-checked">`input`</a>
               </td>
               <td class="aria">
                 <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="true"
@@ -3886,7 +3886,7 @@
             <tr tabindex="-1" id="att-checked-absent">
               <th>`checked` (if absent)</th>
               <td class="elements">
-                <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-checked">`input`</a>
+                <a data-cite="html/input.html#attr-input-checked">`input`</a>
               </td>
               <td class="aria">
                 <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a> (state)="false"
@@ -3908,7 +3908,7 @@
               <td class="ia2"><div class="general">Not mapped</div></td>
               <td class="uia"><div class="general">Not mapped</div></td>
               <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><code>AXURL: &lt;value&gt;</code></td>
+              <td class="ax">`AXURL: &lt;value&gt;`</td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-class">
@@ -3961,7 +3961,9 @@
             </tr>
             <tr tabindex="-1" id="att-content">
               <th><code>content</code></th>
-              <td class="elements"><a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-meta-content"><code>meta</code></a></td>
+              <td class="elements">
+                <a data-cite="html/semantics.html#attr-meta-content">`meta`</a>
+              </td>
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2"><div class="general">Not mapped</div></td>
               <td class="uia"><div class="general">Not mapped</div></td>
@@ -3970,44 +3972,44 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-contenteditable">
-                <th><code>contenteditable</code></th>
-                <td class="elements">
-                  <a data-cite="html/interaction.html#attr-contenteditable">HTML elements</a>
-                </td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="states">
-                    <span class="type">States:</span>
-                    `IA2_STATE_EDITABLE` on this and every nested text accessible object
-                  </div>
-                  <div class="interfaces">
-                    <span class="type">Interfaces:</span>
-                    `IAccessibleEditableText` on this and every nested text accessible object
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Pattern:</span> `TextEdit`
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="states">
-                    <span class="type">States:</span>
-                    `ATK_STATE_EDITABLE` on this and every nested text accessible object
-                  </div>
-                  <div class="interfaces">
-                    <span class="type">Interfaces:</span>
-                    `AtkEditableText` on this and every nested text accessible object
-                  </div>
-                </td>
-                <td class="ax">
-                  <span class="type">Role:</span>
-                  <a href="#el-textarea">AXtextArea</a>
-                  <div class="general">Use WAI-ARIA mapping</div>
-                </td>
-                <td class="comments">
-                  If the element has the `contenteditable` attribute  and `aria-readonly="true"`, User Agents MUST expose only the `contenteditable` state.
-                </td>
+              <th>`contenteditable`</th>
+              <td class="elements">
+                <a data-cite="html/interaction.html#attr-contenteditable">HTML elements</a>
+              </td>
+              <td class="aria">?</td>
+              <td class="ia2">
+                <div class="states">
+                  <span class="type">States:</span>
+                  `IA2_STATE_EDITABLE` on this and every nested text accessible object
+                </div>
+                <div class="interfaces">
+                  <span class="type">Interfaces:</span>
+                  `IAccessibleEditableText` on this and every nested text accessible object
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Pattern:</span> `TextEdit`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="states">
+                  <span class="type">States:</span>
+                  `ATK_STATE_EDITABLE` on this and every nested text accessible object.
+                </div>
+                <div class="interfaces">
+                  <span class="type">Interfaces:</span>
+                  `AtkEditableText` on this and every nested text accessible object.
+                </div>
+              </td>
+              <td class="ax">
+                <span class="type">Role:</span>
+                <a href="#el-textarea">AXtextArea</a>
+                <div class="general">Use WAI-ARIA mapping</div>
+              </td>
+              <td class="comments">
+                If the element has the `contenteditable` attribute  and `aria-readonly="true"`, User Agents MUST expose only the `contenteditable` state.
+              </td>
             </tr>
             <tr tabindex="-1" id="att-controls">
               <th>`controls`</th>
@@ -4122,15 +4124,15 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-decoding">
-              <th>`default`</th>
+              <th>`decoding`</th>
               <td class="elements">
                 <a data-cite="html/embedded-content.html#attr-img-decoding">`img`</a>
               </td>
               <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">???</div></td>
-              <td class="uia"><div class="general">???</div></td>
-              <td class="atk"><div class="general">???</div></td>
-              <td class="ax"><div class="general">???</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-default">
@@ -4195,63 +4197,79 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-disabled">
-                <th><code>disabled</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>button</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-fieldset-disabled"><code>fieldset</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>input</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-optgroup-disabled"><code>optgroup</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-option-disabled"><code>option</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-disabledformelements-disabled"><code>textarea</code></a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue"><code>aria-disabled</code></a>="true"</td>
-                <td class="ia2">
-                  <div class="states">
-                    <span class="type">States:</span> `STATE_SYSTEM_UNAVAILABLE`
-                  </div>
-                </td>
-                <td class="uia"></td>
-                <td class="atk">
-                  <div class="states">
-                    <span class="type">States: </span>
-                    No interactive states like <code>ATK_STATE_FOCUSABLE</code>
-                  </div>
-                </td>
-                <td class="ax"><code>AXEnabled: NO</code></td>
-                <td class="comments">If the element includes both the <code>disabled</code> attribute and the <code>aria-disabled</code> attribute with a valid value, User Agents MUST expose only the <code>disabled</code> attribute value.</td>
+              <th>`disabled`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`button`</a>;
+                <a data-cite="html/form-elements.html#attr-fieldset-disabled">`fieldset`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`input`</a>;
+                <a data-cite="html/form-elements.html#attr-optgroup-disabled">`optgroup`</a>;
+                <a data-cite="html/form-elements.html#attr-option-disabled">`option`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`select`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`textarea`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a></td>
+              <td class="ia2">
+                <div class="states">
+                  <span class="type">States:</span> `STATE_SYSTEM_UNAVAILABLE`
+                </div>
+              </td>
+              <td class="uia"></td>
+              <td class="atk">
+                <div class="states">
+                  <span class="type">States:</span>
+                  No interactive states like `ATK_STATE_FOCUSABLE`
+                </div>
+              </td>
+              <td class="ax">`AXEnabled: NO`</td>
+              <td class="comments">
+                If the element includes both the `disabled` attribute and the `aria-disabled` attribute with a valid value, User Agents MUST expose only the `disabled` attribute value.
+              </td>
             </tr>
             <tr tabindex="-1" id="att-download">
-                <th><code>download</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-download"><code>a</code></a>; <a href="https://www.w3.org/TR/html/links.html#element-attrdef-a-download"><code>area</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`download`</th>
+              <td class="elements">
+                <a data-cite="html/links.html#attr-hyperlink-download">`a` and `area`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-draggable">
-                <th><code>draggable</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-draggable" title="attr-draggable">HTML elements</a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="objattrs">
-                    <span class="objattrs">Object attributes: </span>
-                    draggable:true
-                  </div>
-                </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk">
-                  <div class="objattrs">
-                    <span class="objattrs">Object attributes: </span>
-                    draggable:true
-                  </div>
-                </td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`draggable`</th>
+              <td class="elements">
+                <a data-cite="html/dnd.html#the-draggable-attribute">HTML elements</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="objattrs">
+                  <span class="objattrs">Object attributes: </span>
+                  draggable:true
+                </div>
+              </td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk">
+                <div class="objattrs">
+                  <span class="objattrs">Object attributes: </span>
+                  draggable:true
+                </div>
+              </td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-enctype">
-                <th><code>enctype</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-form-enctype"><code>form</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`enctype`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fs-enctype">`form`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-for-label">
                 <th><code>for</code></th>

--- a/index.html
+++ b/index.html
@@ -3586,133 +3586,151 @@
           </thead>
           <tbody>
             <tr tabindex="-1" id="att-abbr">
-                <th><code>abbr</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/tabular-data.html#element-attrdef-th-abbr"><code>th</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="objattrs">
-                    <span class="type">Object attributes: </span>
-                    "abbr" until child <a href="#el-abbr"><code>abbr</code></a> element is provided
-                  </div>
-                </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk">
-                  <div class="objattrs">
-                    <span class="type">Object attributes: </span>
-                    "abbr" until child <a href="#el-abbr"><code>abbr</code></a> element is provided
-                  </div>
-                </td>
-                <td class="ax"><code>AXDescription: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`abbr`</th>
+              <td class="elements">
+                <a data-cite="html/tables.html#attr-th-abbr">`th`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span>
+                  "abbr" until child <a href="#el-abbr">`abbr`</a> element is provided
+                </div>
+              </td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk">
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span>
+                  "abbr" until child <a href="#el-abbr">`abbr`</a> element is provided
+                </div>
+              </td>
+              <td class="ax">`AXDescription: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-accept">
-                <th><code>accept</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-accept"><code>input</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`accept`</th>
+              <td class="elements">
+                <a data-cite="html/input.html#attr-input-accept">`input`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-accept-charset">
-                <th><code>accept-charset</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-form-accept-charset"><code>form</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`accept-charset`</th>
+              <td class="elements">
+                <a data-cite="html/forms.html#attr-form-accept-charset">`form`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-accesskey">
-                <th><code>accesskey</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-accesskey"><code>HTML elements</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="general">
-                    a key binding accessible by
-                    <a href="https://msdn.microsoft.com/en-us/library/accessibility.iaccessible.acckeyboardshortcut.aspx"><code>accKeyboardShortcut</code></a>
-                    and <code>IAccessibleAction::keyBinding</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="properties">
-                    <span class="type">Properties: </span><code>AccessKey: &lt;value&gt;</code>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    <code>atk_action_get_keybinding</code>
-                  </div>
-                </td>
-                <td class="ax"><code>AXAccessKey: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`accesskey`</th>
+              <td class="elements">
+                <a data-cite="html/interaction.html#the-accesskey-attribute">`HTML elements`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="general">
+                  a key binding accessible by
+                  <a href="https://msdn.microsoft.com/en-us/library/accessibility.iaccessible.acckeyboardshortcut.aspx">`accKeyboardShortcut`</a>
+                  and `IAccessibleAction::keyBinding`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="properties">
+                  <span class="type">Properties: </span>`AccessKey: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  `atk_action_get_keybinding`
+                </div>
+              </td>
+              <td class="ax">`AXAccessKey: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-action">
-                <th><code>action</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-form-action"><code>form</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`action`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fs-action">`form`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
             </tr>
             <tr tabindex="-1" id="att-allowfullscreen">
-                <th>`allowfullscreen`</th>
-                <td class="elements"><a data-cite=
-            "html/iframe-embed-object.html#attr-iframe-allowfullscreen">`iframe`</a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`allowfullscreen`</th>
+              <td class="elements">
+                <a data-cite="html/iframe-embed-object.html#attr-iframe-allowfullscreen">`iframe`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-alt">
-                <th><code>alt</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-area-alt"><code>area</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-img-alt"><code>img</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-alt"><code>input</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  Used for <a class="termref">accessible name</a>, exposed via <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx"><code>accName</code></a>
-                </td>
-                <td class="uia">
-                  <div class="properties">
-                        <span class="type">Properties: </span><a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx"><code>Name</code></a>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    Used for <a class="termref">accessible name</a>, exposed via
-                    <code>atk_object_get_name</code>
-                  </div>
-                </td>
-                <td class="ax"><code>AXDescription: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`alt`</th>
+              <td class="elements">
+                <a data-cite="html/image-maps.html#attr-area-alt">`area`</a>;
+                <a data-cite="html/embedded-content.html#attr-img-alt">`img`</a>;
+                <a data-cite="html/input.html#attr-input-alt">`input`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                Used for <a class="termref">accessible name</a>,
+                exposed via <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx">`accName`</a>
+              </td>
+              <td class="uia">
+                <div class="properties">
+                  <span class="type">Properties:</span>
+                  <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx">`Name`</a>
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  Used for <a class="termref">accessible name</a>, exposed via `atk_object_get_name`
+                </div>
+              </td>
+              <td class="ax">`AXDescription: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-as">
-                <th>`as`</th>
-                <td class="elements">
-                  <a data-cite=
-            "html/semantics.html#attr-link-as">`link`</a>
-                </td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`as`</th>
+              <td class="elements">
+                <a data-cite="html/semantics.html#attr-link-as">`link`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-async">
-                <th><code>async</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-async"><code>script</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`async`</th>
+              <td class="elements">
+                <a data-cite="html/scripting.html#attr-script-async">`script`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-autocomplete-form">
                 <th>`autocomplete` "on|off"</th>

--- a/index.html
+++ b/index.html
@@ -4779,6 +4779,18 @@
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>
+            <tr tabindex="-1" id="att-name-slot">
+              <th>`name`</th>
+              <td class="elements">
+                <a data-cite="html/scripting.html#attr-slot-name">`slot`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
             <tr tabindex="-1" id="att-novalidate">
                 <th><code>novalidate</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-form-novalidate"><code>form</code></a></td>
@@ -4871,24 +4883,28 @@
                 <td class="comments"><div class="general">When the <code>placeholder</code> and <code>aria-placeholder</code> attributes are both present, and the <code>placeholder</code> attribute's value is non-empty, user agents MUST expose the value of the <code>placeholder</code> attribute, and ignore <code>aria-placeholder</code>. If the <code>placeholder</code> attribute's value is empty, then user agents MUST expose the value of the <code>aria-placeholder</code> attribute.</div></td>
             </tr>
             <tr tabindex="-1" id="att-poster">
-                <th><code>poster</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-video-poster"><code>video</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`poster`</th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-video-poster">`video`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-preload">
-                <th><code>preload</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-preload"><code>audio</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-preload"><code>video</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><code>preload</code></th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-media-preload">`audio` and `video`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-readonly">
                 <th><code>readonly</code></th>
@@ -5033,14 +5049,41 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-sizes">
-                <th><code>sizes</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/links.html#element-attrdef-link-sizes"><code>link</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`sizes`</th>
+              <td class="elements">
+                <a data-cite="html/semantics.html#attr-link-sizes">`link`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-sizes-img-source">
+              <th>`sizes`</th>
+              <td class="elements">
+                <a data-cite="html/embedded-content.html#attr-img-sizes">`img`</a>;
+                <a data-cite="html/embedded-content.html#attr-source-sizes">`source`</a>
+              </td>
+              <td class="aria"><div class="general">???</div></td>
+              <td class="ia2"><div class="general">???</div></td>
+              <td class="uia"><div class="general">???</div></td>
+              <td class="atk"><div class="general">???</div></td>
+              <td class="ax"><div class="general">???</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-slot">
+              <th>`slot`</th>
+              <td class="elements">
+                <a data-cite="html/dom.html#the-id-attribute">HTML elements</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-span">
                 <th><code>span</code></th>
@@ -5114,24 +5157,29 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-srcdoc">
-                <th><code>srcdoc</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-iframe-srcdoc"><code>iframe</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`srcdoc`</th>
+              <td class="elements">
+                <a data-cite="html/iframe-embed-object.html#attr-iframe-srcdoc">`iframe`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-srclang">
-                <th><code>srclang</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-track-srclang"><code>track</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`srclang`</th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-track-srclang">`track`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
             </tr>
             <tr tabindex="-1" id="att-start">
                 <th><code>start</code></th>
@@ -5344,7 +5392,7 @@
             </tr>
             <tr tabindex="-1" id="att-type-embed">
                 <th><code>type</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-embed-type"><code>embed</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-object-type"><code>object</code></a>; <a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-type"><code>script</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#dom-source-type"><code>source</code></a>; <a href="https://www.w3.org/TR/html/document-metadata.html#element-attrdef-style-type"><code>style</code></a></td>
+                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-embed-type"><code>embed</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-object-type"><code>object</code></a>; <a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-script-type"><code>script</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#dom-source-type"><code>source</code></a></td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
@@ -5383,17 +5431,6 @@
                 <td class="ax">?</td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="att-type-menu">
-                <th><code>type</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/interactive-elements.html#element-attrdef-menu-type"><code>menu</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax">?</td>
-                <td class="comments"></td>
-            </tr>
-
             <tr tabindex="-1" id="att-type-ol">
                 <th><code>type</code></th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/grouping-content.html#element-attrdef-ol-type"><code>ol</code></a></td>
@@ -5436,37 +5473,29 @@
                   <div class="general">Some platforms (IAccessible2, ATK, UIA) do not expose an <a class="termref">accessible object</a> for the list item marker, whether it was created and then pruned from the <a class="termref">accessibility tree</a>, or never created in the first place. Instead, they expose the list item marker as part of the associated list item's accessible text. In these cases, implementors need to consider such things as adjusting the offsets (e.g. for caret-moved events, text-selection events, etc.) for the updated list item text that now also contains the list item marker as content, rather than just taking the offsets unmodified from the list item renderer.</div>
                 </td>
             </tr>
-            <tr tabindex="-1" id="att-typemustmatch">
-                <th><code>typemustmatch</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-object-typemustmatch"><code>object</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
-            </tr>
             <tr tabindex="-1" id="att-usemap">
-                <th><code>usemap</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-img-usemap"><code>img</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="general">
-                    Responsible for image map creation, refer to <a href="#el-img"><code>img</code></a> element
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    Responsible for image map creation, refer to <a href="#el-img"><code>img</code></a> element
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    Responsible for image map creation, refer to <a href="#el-img"><code>img</code></a> element
-                  </div>
-                </td>
-                <td class="ax">?</td>
-                <td class="comments"></td>
+              <th>`usemap`</th>
+              <td class="elements">
+                <a data-cite="html/image-maps.html#attr-hyperlink-usemap">`img` and `object`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="general">
+                  Responsible for image map creation.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  Responsible for image map creation.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  Responsible for image map creation.
+                </div>
+              </td>
+              <td class="ax">?</td>
+              <td class="comments">Refer to <a href="#el-img">`img`</a> element.</td>
             </tr>
             <tr tabindex="-1" id="att-value-button">
                 <th><code>value</code></th>
@@ -5587,8 +5616,10 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-wrap">
-              <th><code>wrap</code></th>
-              <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-textarea-wrap"><code>textarea</code></a></td>
+              <th>`wrap`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-textarea-wrap">`textarea`</a>
+              </td>
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2"><div class="general">Not mapped</div></td>
               <td class="uia"><div class="general">Not mapped</div></td>

--- a/index.html
+++ b/index.html
@@ -3923,7 +3923,7 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="att-class">
+            <tr tabindex="-1" id="att-color">
               <th>`color`</th>
               <td class="elements">
                 <a data-cite="html/semantics.html#attr-link-color">`link`</a>

--- a/index.html
+++ b/index.html
@@ -3669,11 +3669,34 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
+            <tr tabindex="-1" id="att-allow">
+              <th>`allow`</th>
+              <td class="elements">
+                <a data-cite="html/iframe-embed-object.html#attr-iframe-allow">`iframe`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-allowfullscreen">
               <th>`allowfullscreen`</th>
               <td class="elements">
                 <a data-cite="html/iframe-embed-object.html#attr-iframe-allowfullscreen">`iframe`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-allowpaymentrequest">
+              <th>`allowpaymentrequest`</th>
+              <td class="elements">
+                <a data-cite="html/iframe-embed-object.html#attr-iframe-allowpaymentrequest">`iframe`</a>
               </td>
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2"><div class="general">Not mapped</div></td>
@@ -3724,6 +3747,18 @@
               <th>`async`</th>
               <td class="elements">
                 <a data-cite="html/scripting.html#attr-script-async">`script`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-autocapitalize">
+              <th>`autocapitalize`</th>
+              <td class="elements">
+                <a data-cite="html/interaction.html#attr-autocapitalize">HTML elements</a>
               </td>
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2"><div class="general">Not mapped</div></td>

--- a/index.html
+++ b/index.html
@@ -3768,73 +3768,82 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-autocomplete-form">
-                <th>`autocomplete` "on|off"</th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-autocompleteelements-autocomplete"><code>form</code></a></td>
-                <td class="aria"><p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code></a></p>
-              <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p></td>
-                <td class="ia2">
-                  <div class="states">
-                    <span class="type">States: </span>
-                    <code>STATE_SUPPORTS_AUTOCOMPLETION</code> on text form controls until the value is overridden by control
-                  </div>
-                </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk">
-                  <div class="states">
-                    <span class="type">States: </span>
-                    <code>ATK_STATE_SUPPORTS_AUTOCOMPLETION</code>
-                    on text form controls until the value is overridden by control
-                  </div>
-                </td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments">If the element includes both <code>autocomplete</code> and <code>aria-autocomplete</code> attributes with valid values, User Agents MUST expose only the <code>autocomplete</code> attribute value. </td>
+              <th>`autocomplete` "on|off"</th>
+              <td class="elements">
+                <a data-cite="html/forms.html#attr-form-autocomplete">`form`</a>
+              </td>
+              <td class="aria">
+                <p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth">`aria-autocomplete`</a></p>
+                <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p>
+              </td>
+              <td class="ia2">
+                <div class="states">
+                  <span class="type">States:</span>
+                  `STATE_SUPPORTS_AUTOCOMPLETION` on text form controls until the value is overridden by control
+                </div>
+              </td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk">
+                <div class="states">
+                  <span class="type">States:</span>
+                  `ATK_STATE_SUPPORTS_AUTOCOMPLETION` on text form controls until the value is overridden by control
+                </div>
+              </td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments">
+                If the element includes both `autocomplete` and `aria-autocomplete` attributes with valid values, User Agents MUST expose only the `autocomplete` attribute value.
+              </td>
             </tr>
-             <tr tabindex="-1" id="att-autocomplete">
-                <th><code>autocomplete</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-autocompleteelements-autocomplete"><code>input</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-autocompleteelements-autocomplete"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-autocompleteelements-autocomplete"><code>textarea</code></a></td>
-                <td class="aria"><p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth"><code>aria-autocomplete</code></a></p>
-              <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p></td>
-                <td class="ia2">
-                  <div class="states">
-                    <span class="type">States: </span>
-                    <code>STATE_SUPPORTS_AUTOCOMPLETION</code>
-                  </div>
-                </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk">
-                  <div class="states">
-                    <span class="type">States: </span>
-                    <code>ATK_STATE_SUPPORTS_AUTOCOMPLETION</code>
-                  </div>
-                </td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments">If the element includes both <code>autocomplete</code> and <code>aria-autocomplete</code> attributes with valid values, User Agents MUST expose only the <code>autocomplete</code> attribute value. </td>
+            <tr tabindex="-1" id="att-autocomplete">
+              <th>`autocomplete`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-autocomplete">`input`, `select` and `textarea`</a>
+              </td>
+              <td class="aria">
+                <p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth">`aria-autocomplete`</a></p>
+                <p><strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.</p>
+              </td>
+              <td class="ia2">
+                <div class="states">
+                  <span class="type">States:</span> `STATE_SUPPORTS_AUTOCOMPLETION`
+                </div>
+              </td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk">
+                <div class="states">
+                  <span class="type">States:</span> `ATK_STATE_SUPPORTS_AUTOCOMPLETION`
+                </div>
+              </td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments">
+                If the element includes both `autocomplete` and `aria-autocomplete` attributes with valid values, User Agents MUST expose only the `autocomplete` attribute value.
+              </td>
             </tr>
             <tr tabindex="-1" id="att-autofocus">
-                <th>`autofocus`</th>
-                <td class="elements">
-                  <a data-cite="html/interaction.html#attr-fe-autofocus">HTML elements</a>
-                </td>
-                <td class="aria">Not mapped</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments">
-                  Similar to <a class="core-mapping" href="#ariaFlowto"><code>aria-flowto</code></a>.
-                </td>
+              <th>`autofocus`</th>
+              <td class="elements">
+                <a data-cite="html/interaction.html#attr-fe-autofocus">HTML elements</a>
+              </td>
+              <td class="aria">Not mapped</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments">
+                <p>Similar to <a class="core-mapping" href="#ariaFlowto">`aria-flowto`</a>.</p>
+              </td>
             </tr>
             <tr tabindex="-1" id="att-autoplay">
-                <th><code>autoplay</code></th>
-                <td class="elements">
-                  <a data-cite="html/media.html#attr-media-autoplay">`audio` and `video`</a>
-                </td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`autoplay`</th>
+              <td class="elements">
+                <a data-cite="html/media.html#attr-media-autoplay">`audio` and `video`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-charset-meta">
               <th>`charset`</th>


### PR DESCRIPTION
more clean up to the doc source and fixes attribute links to the HTML specification.

Adds missing attributes that have no accessibility mappings (related to completing #97): 
* `decoding` for `img` element
* `allow`
* `allowpaymentrequest`
* `autocapitalize`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/243.html" title="Last updated on Sep 14, 2019, 8:05 PM UTC (7b9ec93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/243/e1b1ba9...7b9ec93.html" title="Last updated on Sep 14, 2019, 8:05 PM UTC (7b9ec93)">Diff</a>