### PR TITLE
Update ARIA mappings for various meter and input related attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6321,7 +6321,7 @@
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
             <li>23-Sept-2019: Update attribute mappings for `high`, `low`, `max`, `min`, and `meter` and `progress`'s `value` attribute.  See <a href="https://github.com/w3c/html-aam/pull/244">GitHub pull request #244</a>.</li>
-            <li>18-Sept-2019: Update `mark` element's UIA `LocalizedControlType` and AX `AXRoleDescription`.  See <a href="https://github.com/w3c/html-aam/issues/236">GitHub issue 236</a>.</li>
+            <li>18-Sept-2019: Update `mark` element's UIA `LocalizedControlType` and AX `AXRoleDescription`.  See <a href="https://github.com/w3c/html-aam/issues/236">GitHub issue #236</a>.</li>
             <li>18-Sept-2019: Update ATK mappings for `summary` and `details` elements. See <a href="https://github.com/w3c/html-aam/issues/142">GitHub issue #142</a> and <a href="https://github.com/w3c/html-aam/issues/147">GitHub issue #147</a>.</li>
             <li>18-Sept-2019: Update MSAA mappings for `sub` and `sup`. See <a href="https://github.com/w3c/html-aam/pull/252">GitHub pull request #252</a>.</li>
             <li>11-Sept-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`.  Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a>.</li>

--- a/index.html
+++ b/index.html
@@ -5649,26 +5649,33 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-value-meter">
-                <th><code>value</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-meter-value"><code>meter</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-progress-value"><code>progress</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="general">
-                    Exposed as <code>IAccessibleValue::currentValue</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    Exposed as <code>Value.Value</code>
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    Exposed as <code>atk_value_get_current_value</code>
-                  </div>
-                </td>
-                <td class="ax"><code>AXValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`value`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-meter-value">`meter`</a>;
+                <a data-cite="html/form-elements.html#attr-progress-value">`progress`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as `IAccessibleValue::currentValue`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  Exposed as `Value.Value`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as `atk_value_get_current_value`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="general">
+                  `AXValue: &lt;value&gt;`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-value-param">
                 <th><code>value</code></th>

--- a/index.html
+++ b/index.html
@@ -6312,6 +6312,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
+            <li>23-Sept-2019: Update attribute mappings for `high`, `low`, `max`, `min`, and `meter` and `progress`'s `value` attribute.  See <a href="https://github.com/w3c/html-aam/pull/244">GitHub pull request #244</a>.</li>
             <li>11-Sept-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`.  Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a>.</li>
             <li>10-July-2019: Further updated mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/pull/219">GitHub pull request #219</a>.</li>
             <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>

--- a/index.html
+++ b/index.html
@@ -4438,14 +4438,16 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-high">
-                <th><code>high</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-meter-high"><code>meter</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><code>RangeValue.Maximum</code></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`high`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-meter-high">`meter`</a>
+              </td>
+              <td class="aria">Not mapped</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia">`RangeValue.Maximum`</td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-href">
                 <th><a data-cite=
@@ -4596,7 +4598,7 @@
                   <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-list"><code>input</code></a>
                 </td>
                 <td class="aria">
-                  <a class="core-mapping" href="#ariaControls"><code>aria-controls</code></a>
+                  <a class="core-mapping" href="#ariaControls">`aria-controls`</a>
                 </td>
                 <td class="ia2">
                   <div class="relations">
@@ -4652,7 +4654,7 @@
               <th><code>low</code></th>
               <td class="elements"><a data-cite=
             "html/form-elements.html#attr-meter-low">`meter`</a></td>
-                <td class="aria">?</td>
+                <td class="aria">Not mapped</td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><code>RangeValue.Minimum</code></td>
                 <td class="atk"><div class="general">Not mapped</div></td>
@@ -4660,44 +4662,45 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-max-input">
-                <th><code>max</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-max"><code>input</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="general">
-                    Exposed as <code>IAccessibleValue::maximumValue</code> if the element
-                    implements the interface
-                  </div>
-                </td>
-                <td class="uia"><code>RangeValue.Maximum</code></td>
-                <td class="atk">
-                  <div class="general">
-                    Exposed as <code>atk_value_get_maximum_value</code> if the element
-                    implements the <code>AtkValue</code> interface
-                  </div>
-                </td>
-                <td class="ax"><code>AXMaxValue: &lt;value&gt;</code></td>
+              <th>`max`</th>
+              <td class="elements">
+                <a data-cite="html/input.html#attr-input-max">`input`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as `IAccessibleValue::maximumValue` if the element implements the interface
+                </div>
+              </td>
+              <td class="uia">`RangeValue.Maximum`</td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface
+                </div>
+              </td>
+              <td class="ax">`AXMaxValue: &lt;value&gt;`</td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-max">
-                <th><code>max</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-meter-max"><code>meter</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-progress-max"><code>progress</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="general">
-                    Exposed as <code>IAccessibleValue::maximumValue</code> if the element
-                    implements the interface
-                  </div>
-                </td>
-                <td class="uia"><code>RangeValue.Maximum</code></td>
-                <td class="atk">
-                  <div class="general">
-                    Exposed as <code>atk_value_get_maximum_value</code> if the element
-                    implements the <code>AtkValue</code> interface
-                  </div>
-                </td>
-                <td class="ax"><code>AXMaxValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`max`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-meter-max">`meter`</a>;
+                <a data-cite="html/form-elements.html#attr-progress-max">`progress`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as `IAccessibleValue::maximumValue` if the element implements the interface
+                </div>
+              </td>
+              <td class="uia">`RangeValue.Maximum`</td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface
+                </div>
+              </td>
+              <td class="ax">`AXMaxValue: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-maxlength">
                 <th><code>maxlength</code></th>
@@ -4730,44 +4733,46 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-min-input">
-                <th><code>min</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-min"><code>input</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="general">
-                    Exposed as <code>IAccessibleValue::minimumValue</code> if the element
-                    implements the interface
-                  </div>
-                </td>
-                <td class="uia"><code>RangeValue.Minimum</code></td>
-                <td class="atk">
-                  <div class="general">
-                    Exposed as <code>atk_value_get_minimum_value</code> if the element
-                    implements the <code>AtkValue</code> interface
-                  </div>
-                </td>
-                <td class="ax"><code>AXMinValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`min`</th>
+              <td class="elements">
+                <a data-cite="html/input.html#attr-input-min">`input`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as `IAccessibleValue::minimumValue` if the element
+                  implements the interface
+                </div>
+              </td>
+              <td class="uia">`RangeValue.Minimum`</td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as `atk_value_get_minimum_value` if the element
+                  implements the `AtkValue` interface
+                </div>
+              </td>
+              <td class="ax">`AXMinValue: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-min">
-                <th><code>min</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-meter-min"><code>meter</code></a></td>
-                <td class="aria">?</td>
-                <td class="ia2">
-                  <div class="general">
-                    Exposed as <code>IAccessibleValue::minimumValue</code> if the element
-                    implements the interface
-                  </div>
-                </td>
-                <td class="uia"><code>RangeValue.Minimum</code></td>
-                <td class="atk">
-                  <div class="general">
-                    Exposed as <code>atk_value_get_minimum_value</code> if the element
-                    implements the <code>AtkValue</code> interface
-                  </div>
-                </td>
-                <td class="ax"><code>AXMinValue: &lt;value&gt;</code></td>
-                <td class="comments"></td>
+              <th>`min`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-meter-min">`meter`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as `IAccessibleValue::minimumValue` if the element implements the interface
+                </div>
+              </td>
+              <td class="uia">`RangeValue.Minimum`</td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as `atk_value_get_minimum_value` if the element implements the `AtkValue` interface
+                </div>
+              </td>
+              <td class="ax">`AXMinValue: &lt;value&gt;`</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-multiple-input">
                 <th><code>multiple</code></th>
@@ -4918,14 +4923,16 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-optimum">
-                <th><code>optimum</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-meter-optimum"><code>meter</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`optimum`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-meter-optimum">`meter`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-pattern">
                 <th><code>pattern</code></th>


### PR DESCRIPTION
While the `meter` role will be defined in ARIA 1.2, the attribute mappings for `min` and `max` are availalbe now, so we should point to those.

This commit also updates the HTML attr links for these attributes.

Additionally, ARIA 1.2 notes that an attribute for `low`, `high` and `optimum` will not be made until ARIA 1.3, if at all.  Those HTML attribute ARIA mappings have also been updated as necessary.

@stevefaulkner, @joanmarie do either of you have any reason to think we should wait to merge these changes until `role=meter` officially lands?  Also, I was thinking we can just trim down the other cell entries to "Use WAI-ARIA mapping", unless you think there's value in keeping the "if the element implements the interface" text that's currently in the table cells. Thoughts?

Related to issue #229 and #97 

The following tasks have been completed:
* [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
* [x] Update change log if this PR is good to merge now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/244.html" title="Last updated on Sep 23, 2019, 4:15 PM UTC (3ff8ca7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/244/787e741...3ff8ca7.html" title="Last updated on Sep 23, 2019, 4:15 PM UTC (3ff8ca7)">Diff</a>