### PR TITLE
Removal of obsolete elements RB and RTC

### DIFF
--- a/index.html
+++ b/index.html
@@ -6351,7 +6351,7 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
-            <li>22-Sept-2019: Remove mappings for `rb` and `rtc` elements as they are marked as obsolete in HTML. See <a href="https://github.com/w3c/html-aam/issues/115">GitHub issue #115</a> and <a href="https://github.com/w3c/html-aam/pull/252">pull request #253</a>.
+            <li>22-Sept-2019: Remove mappings for `rb` and `rtc` elements as they are marked as obsolete in HTML. See <a href="https://github.com/w3c/html-aam/issues/115">GitHub issue #115</a> and <a href="https://github.com/w3c/html-aam/pull/253">pull request #253</a>.
             <li>18-Sept-2019: Update `mark` element's UIA `LocalizedControlType` and AX `AXRoleDescription`. See <a href="https://github.com/w3c/html-aam/issues/236">GitHub issue 236</a>.</li>
             <li>18-Sept-2019: Update ATK mappings for `summary` and `details` elements. See <a href="https://github.com/w3c/html-aam/issues/142">GitHub issue #142</a> and <a href="https://github.com/w3c/html-aam/issues/147">GitHub issue #147</a>.</li>
             <li>18-Sept-2019: Update MSAA mappings for `sub` and `sup`. See <a href="https://github.com/w3c/html-aam/pull/252">GitHub pull request #252</a>.</li>

--- a/index.html
+++ b/index.html
@@ -2762,27 +2762,43 @@
                 </td>
                 <td class="comments"></td>
             </tr>
+            <!--
+              *** Marked as obsolete in HTML. ***
 
-            <tr tabindex="-1" id="el-rb">
-                <th><a href="https://w3c.github.io/html/textlevel-semantics.html#the-rb-element"><code>rb</code></a></th>
+              <tr tabindex="-1" id="el-rb">
+                <th>
+                  <a href="https://html.spec.whatwg.org/#rb">`rb`</a>
+                </th>
                 <td class="aria">No corresponding role</td>
-                <td class="ia2">?</td>
-                <td class="uia">?</td>
-                <td class="atk">?</td>
-                <td class="ax">
+                <td class="ia2">
                   <div class="role">
-                    <span class="type">AXRole: </span><code>AXGroup</code>
-                  </div>
-                  <div class="subrole">
-                      <span class="type">AXSubrole: </span><code>AXRubyBase</code>
-                  </div>
-                  <div class="roledesc">
-                      <span class="type">AXRoleDescription: </span><code>"group"</code>
+                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
                   </div>
                 </td>
-                <td class="comments"></td>
-            </tr>
-
+                <td class="uia">
+                  <div class="ctrltype">
+                    <span class="type">Control Type:</span> `Text`
+                  </div>
+                </td>
+                <td class="atk">
+                  <div class="role">
+                    <span class="type">Role:</span> `ATK_ROLE_STATIC`
+                  </div>
+                </td>
+                <td class="ax">
+                  <div class="role">
+                    <span class="type">AXRole:</span> `AXGroup`
+                  </div>
+                  <div class="subrole">
+                    <span class="type">AXSubrole:</span> `AXRubyBase`
+                  </div>
+                  <div class="roledesc">
+                    <span class="type">AXRoleDescription:</span> `"group"`
+                  </div>
+                </td>
+                <td class="comments"><a href="https://html.spec.whatwg.org/#rb">Marked as Obsolete in HTML</a>.</td>
+              </tr>
+            -->
             <tr tabindex="-1" id="el-rp">
                 <th><a data-cite="HTML">`rp`</a></th>
                 <td class="aria">No corresponding role</td>
@@ -2836,15 +2852,44 @@
                 </td>
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-rtc">
-                <th><a href="https://w3c.github.io/html/textlevel-semantics.html#the-rtc-element"><code>rtc</code></a></th>
+            <!--
+              *** Marked as obsolete in HTML. ***
+
+              <tr tabindex="-1" id="el-rtc">
+                <th>
+                  <a href="https://html.spec.whatwg.org/#rtc">`rtc`</a>
+                </th>
                 <td class="aria">No corresponding role</td>
-                <td class="ia2">?</td>
-                <td class="uia">?</td>
-                <td class="atk">?</td>
-                <td class="ax">?</td>
-                <td class="comments"></td>
-            </tr>
+                <td class="ia2">
+                  <div class="role">
+                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+                  </div>
+                </td>
+                <td class="uia">
+                  <div class="ctrltype">
+                    <span class="type">Control Type:</span> `Text`
+                  </div>
+                </td>
+                <td class="atk">
+                  <div class="role">
+                    <span class="type">Role:</span> `ATK_ROLE_STATIC`
+                  </div>
+                </td>
+                <td class="ax">
+                  <div class="role">
+                    <span class="type">AXRole:</span> `AXGroup`
+                  </div>
+                  <div class="subrole">
+                    <span class="type">AXSubrole:</span> `AXRubyBase`
+                  </div>
+                  <div class="roledesc">
+                    <span class="type">AXRoleDescription:</span> `"group"`
+                  </div>
+                </td>
+                <td class="comments">
+                  <a href="https://html.spec.whatwg.org/#rtc">Marked as Obsolete in HTML</a>.</td>
+              </tr>
+            -->
             <tr tabindex="-1" id="el-ruby">
                 <th><a data-cite="HTML">`ruby`</a></th>
                 <td class="aria">No corresponding role</td>
@@ -6306,10 +6351,11 @@
         <section>
           <h4>Substantive changes since moving entirely to the Web Application Working Group (formerly Web Platform WG) (01-Oct-2016)</h4>
           <ul>
-            <li>18-Sept-2019: Update `mark` element's UIA `LocalizedControlType` and AX `AXRoleDescription`.  See <a href="https://github.com/w3c/html-aam/issues/236">GitHub issue 236</a>.</li>
+            <li>22-Sept-2019: Remove mappings for `rb` and `rtc` elements as they are marked as obsolete in HTML. See <a href="https://github.com/w3c/html-aam/issues/115">GitHub issue #115</a> and <a href="https://github.com/w3c/html-aam/pull/252">pull request #253</a>.
+            <li>18-Sept-2019: Update `mark` element's UIA `LocalizedControlType` and AX `AXRoleDescription`. See <a href="https://github.com/w3c/html-aam/issues/236">GitHub issue 236</a>.</li>
             <li>18-Sept-2019: Update ATK mappings for `summary` and `details` elements. See <a href="https://github.com/w3c/html-aam/issues/142">GitHub issue #142</a> and <a href="https://github.com/w3c/html-aam/issues/147">GitHub issue #147</a>.</li>
             <li>18-Sept-2019: Update MSAA mappings for `sub` and `sup`. See <a href="https://github.com/w3c/html-aam/pull/252">GitHub pull request #252</a>.</li>
-            <li>11-Sept-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`.  Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a>.</li>
+            <li>11-Sept-2019: Update mapping for `menu` to match <a data-cite="html/#the-menu-element">HTML Living Standard</a>. Remove element and attribute mappings that are not applicable to `menu` and `menuitem`. Update mapping of `menu` to `role="list"`. See <a href="https://github.com/w3c/html-aam/issues/188">GitHub issue #188</a>.</li>
             <li>10-July-2019: Further updated mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/pull/219">GitHub pull request #219</a>.</li>
             <li>13-June-2019: Update mappings for `ins` and `del` elements. See <a href="https://github.com/w3c/html-aam/issues/141">GitHub issue #141</a>.</li>
             <li>10-June-2019: Update ATK mappings for `header` and `footer` when not scoped to the `body`. See <a href="https://github.com/w3c/html-aam/issues/129">GitHub issue #129</a>.</li>


### PR DESCRIPTION
Closes #115

While this PR fills in mappings for `rb` and the `rtc` elements based on how they are presently mapped, they are also being *commented out* as they are marked as obsolete in the HTML specification.

If consensus can be reached on adding these elements back into the HTML specification, then this PR should be reversed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/253.html" title="Last updated on Oct 1, 2019, 2:03 AM UTC (5b0d019)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/253/3caf0ce...5b0d019.html" title="Last updated on Oct 1, 2019, 2:03 AM UTC (5b0d019)">Diff</a>