### PR TITLE
chore(PULL_REQUEST_TEMPLATE): drop errors check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@ Closes #????
 
 The following tasks have been completed:
 
- * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
  * [ ] Modified Web platform tests (link to pull request)
 
 Implementation commitment:


### PR DESCRIPTION
As we now use the ReSpec validator in .travisci.yaml, this is done automatically on Travis.