### PR TITLE
add hyphen to no-href ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-a-nohref">
+            <tr tabindex="-1" id="el-a-no-href">
               <th>
                 <a data-cite="HTML">`a`</a>
                 <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
@@ -391,7 +391,7 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-area-nohref">
+            <tr tabindex="-1" id="el-area-no-href">
               <th>
                 <a data-cite="HTML">`area`</a>
                 <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>


### PR DESCRIPTION
- for consistency with ARIA in HTML spec convention


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aam/pull/263.html" title="Last updated on Nov 11, 2019, 6:29 PM UTC (7fb4c19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/263/4ed8d79...carmacleod:7fb4c19.html" title="Last updated on Nov 11, 2019, 6:29 PM UTC (7fb4c19)">Diff</a>