### PR TITLE
fix inconsistency nits

### DIFF
--- a/index.html
+++ b/index.html
@@ -1397,7 +1397,7 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr id="el-header2" tabindex="-1">
+            <tr tabindex="-1" id="el-form-no-accessible-name">
               <th>
                 <a data-cite="HTML">`form`</a> without an <a class="termref">accessible name</a>
               </th>
@@ -1611,7 +1611,7 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-img-emptyalt">
+            <tr tabindex="-1" id="el-img-empty-alt">
                 <th><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"><code>img</code></a> <span class="el-context">(<a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-img-alt"><code>alt</code></a> attribute value is an empty string, i.e. <code>alt=""</code> or <code>alt</code> with no value in the markup)</span></th>
                 <td class="aria">
                   <div class="role"><a class="core-mapping" href="#role-map-presentation"><code>presentation</code></a></div>
@@ -2654,7 +2654,7 @@
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>
-            <tr id="el-picture" tabindex="-1">
+            <tr tabindex="-1" id="el-picture">
               <th><a data-cite="HTML">`picture`</a></th>
               <td class="aria">No corresponding role</td>
               <td class="ia2"><div class="general">Not mapped</div></td>


### PR DESCRIPTION
Just fixing a few tiny inconsistencies in the markup for easier parsing and linking (no actual content words were changed):
- ensure all table entries use the same markup: `<tr tabindex="-1" id="el-x">` (2 of them had `tabindex="-1"` after `id`) (consistency makes the spec easier to parse... :)
- the table entry with id="el-header2" is actually a special case of form element (not header), so used "el-form-no-accessible-name" instead
- use hyphen to separate words in id's for consistent naming with ARIA in HTML, i.e. "el-img-empty-alt" (not "emptyalt")


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aam/pull/269.html" title="Last updated on Dec 10, 2019, 1:05 AM UTC (dbd1182)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/269/30372a9...carmacleod:dbd1182.html" title="Last updated on Dec 10, 2019, 1:05 AM UTC (dbd1182)">Diff</a>