### PR TITLE
make `textbox` in textarea mapping table a link into core aam textbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -3355,7 +3355,7 @@
             </tr>
             <tr tabindex="-1" id="el-textarea">
                 <th><a data-cite="HTML">`textarea`</a></th>
-                <td class="aria">textbox role, with the <a class="core-mapping" href="#ariaMultilineTrue"><code>aria-multiline</code></a> property set to "true"</td>
+                <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role, with the <a class="core-mapping" href="#ariaMultilineTrue"><code>aria-multiline</code></a> property set to "true"</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>


### PR DESCRIPTION
Closes #274 

(basically just editorial - fixes missing link)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aam/pull/275.html" title="Last updated on Dec 17, 2019, 11:45 PM UTC (deb6922)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/275/5a2df0c...carmacleod:deb6922.html" title="Last updated on Dec 17, 2019, 11:45 PM UTC (deb6922)">Diff</a>