### PR TITLE
revise step 4 of input type=image accname

### DIFF
--- a/index.html
+++ b/index.html
@@ -6182,7 +6182,7 @@
           <!-- <li>Otherwise use <code>value</code> attribute.</li> -->
           <li>Otherwise use <code>title</code> attribute.</li>
           <li>
-            Otherwise the user agent may provide an <a class="termref">accessible name</a> via a localized string of the phrase &quot;Submit Query&quot;.
+            Otherwise if the previous steps do not yield a usable text string, the <a class="termref">accessible name</a> is a localized string of the word &quot;Submit Query&quot;.
           </li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.


### PR DESCRIPTION
closes #270

purposefully staying away from “MUST”, but removing the ‘may’ in this commit to stay consistent with other input button types.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/279.html" title="Last updated on May 29, 2020, 9:15 PM UTC (2f0ba5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/279/cef092f...2f0ba5a.html" title="Last updated on May 29, 2020, 9:15 PM UTC (2f0ba5a)">Diff</a>