### PR TITLE
issue #282: text level elements not listed elsewhere shouldn't allow …

### DIFF
--- a/index.html
+++ b/index.html
@@ -6613,7 +6613,6 @@
           <li>
             If the element has an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-label">`aria-label`</a> or an <a href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby">`aria-labelledby`</a> attribute the <a class="termref">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>.
           </li>
-          <li>Otherwise use the text element's subtree.</li>
           <li>Otherwise use the `title` attribute.</li>
           <li>
             If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.


### PR DESCRIPTION
…name from content

Text level elements are not mapped to ARIA roles, but ARIA name computation alg strictly defines roles which allow name from content; also the behavior doens't match implementations

Closes #282

> The following tasks have been completed:
>  * [ ] Modified Web platform tests (link to pull request)

how do I do that? not familiar with procedure?

Implementation commitment: already implemented


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/283.html" title="Last updated on Jun 29, 2020, 3:00 AM UTC (2b12716)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/283/83e3540...2b12716.html" title="Last updated on Jun 29, 2020, 3:00 AM UTC (2b12716)">Diff</a>