### PR TITLE
removal of 4.3.1 Other Accessibility Implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,21 +180,8 @@
     </section>
     <section id="mapping_nodirect">
       <h3>Exposing HTML Features That Do Not Directly Map to Accessibility APIs</h3>
-      <p>HTML may have features that are not supported by <a class="termref">accessibility APIs</a> at the time of publication. There is not a one to one relationship between all features and platform <a class="termref">accessibility APIs</a>. When HTML roles, states and properties do not directly map to an <a class="termref">accessibility API</a>, and there is a method in the API to expose a text string, user agents MUST expose the undefined role, states and properties via that method.</p>
+      <p>HTML can include features that are not supported by <a class="termref">accessibility APIs</a> at the time of publication. There is not a one to one relationship between all features and platform <a class="termref">accessibility APIs</a>. When HTML roles, states and properties do not directly map to an <a class="termref">accessibility API</a>, and there is a method in the API to expose a text string, user agents MUST expose the undefined role, states and properties via that method.</p>
       <p>For HTML elements or attributes with default WAI-ARIA semantics, user agents MUST conform to <a class="core-mapping" href="#mapping_nodirect">Exposing attributes that do not directly map to accessibility <abbr title="application programming interface">API</abbr> properties</a> in the [[core-aam-1.2]].</p>
-      <section>
-        <h4>Other Accessibility Implementations</h4>
-        <section>
-          <h5>Use of MSAA VARIANT by Some <a class="termref">User Agents</a></h5>
-          <p>In MSAA, the value of an <a>accessible object</a>'s <a href="https://docs.microsoft.com/en-us/windows/desktop/WinAuto/role-property">Role property</a> is retrieved with the <a href="https://docs.microsoft.com/en-us/windows/desktop/api/oleacc/nf-oleacc-iaccessible-get_accrole">IAccessible::get_accRole method</a>. This method returns a <a href="https://docs.microsoft.com/en-us/windows/desktop/api/oaidl/ns-oaidl-tagvariant">VARIANT</a> that is limited to a finite number of <a href="https://docs.microsoft.com/en-us/windows/desktop/WinAuto/object-roles">integer role constants</a> insufficient for describing the role of every HTML element, especially new elements introduced by HTML. To address this limitation, some user agents, e.g., Firefox and Chrome in cooperation with some screen readers, have elected to expose certain roles by returning a string value (<a href="https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr">BSTR</a>) in that VARIANT in a way that is not described by the MSAA specification.</p>
-          <p>For example, Firefox returns the element's tag name as a BSTR for the following: <a>`abbr`</a>, <a>`address`</a>, <a>`aside`</a>, <a>`blockquote`</a>, <a>`canvas`</a>, <a>`caption`</a>, <a>`dd`</a>, <a>`div`</a>, <a>`figcaption`</a>, <a>`footer`</a>, <a>`form`</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`–`h6`</a>, <a>`header`</a>, <a>`iframe`</a>, <a data-cite="html/input.html#file-upload-state-(type=file)">`input type="file"`</a>, <a>`main`</a>, <a>`menu`</a>, <a>`nav`</a>, <a>`output`</a>, <a>`p`</a>, <a>`pre`</a>, <a>`q`</a>, <a>`section`</a>, <a>`time`</a>.</p>
-          <p>Similarly, Chrome returns the element's tag name for: <a>`blockquote`</a>, <a>`div`</a>, <a>`dl`</a>, <a>`figcaption`</a>, <a>`form`</a>, <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`–`h6`</a>, <a>`menu`</a>, <a>`meter`</a>, <a>`p`</a>, <a>`pre`</a>.</p>
-        </section>
-        <section>
-          <h5>Use of the DOM by Some Assistive Technologies</h5>
-          <p class="ednote">to do</p>
-        </section>
-      </section>
     </section>
     <section>
       <h3>HTML Element Role Mappings</h3>


### PR DESCRIPTION
closes  #285

Also removes “Use of the DOM by Some Assistive Technologies” as it’s been a “TODO” for quite some time now.

we can always add it in when we have content to add, but for now I’d rather we not have a lingering todo in the document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/286.html" title="Last updated on Mar 19, 2020, 10:41 PM UTC (cffc349)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/286/e765269...cffc349.html" title="Last updated on Mar 19, 2020, 10:41 PM UTC (cffc349)">Diff</a>