### PR TITLE
chore: enable ReSpec's a11y feature and remove an empty heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -6554,10 +6554,7 @@
           <li>Otherwise use the `title` attribute.</li>
           <li>If none of the above yield a usable text string there is no <a class="termref">accessible name</a>.</li>
         </ol>
-        <div class="note">
-          <div class="note-title marker" id="xxx" role="heading" aria-level="5"></div>
-          <p>The document referenced by the `src` of the `iframe` element gets its name from that document's `title` element, like any other document. If there is no `title` provided, there is no accessible name.</p>
-        </div>
+        <p class="note">The document referenced by the `src` of the `iframe` element gets its name from that document's `title` element, like any other document. If there is no `title` provided, there is no accessible name.</p>
       </section>
       <section>
         <h4>`iframe` Element Accessible Description Computation</h4>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,8 @@
       },
       xref: ["HTML"],
       localBiblio: localBiblio,
-      preProcess: [ linkCrossReferences ]
+      preProcess: [ linkCrossReferences ],
+      a11y: true
     };
   </script>
   <script>


### PR DESCRIPTION
I enabled [`respecConfig.a11y`](https://github.com/w3c/respec/wiki/a11y) to detect a11y issues in the spec. You can preview the same by visiting [w3c.github.io/html-aam/?a11y=true](https://w3c.github.io/html-aam/?a11y=true). 
Based on that, I found an empty heading in a note, so this PR fixes that.

Note: You might not want to enable `respecConfig.a11y` in live version, as it will substantially slow down the page (I can just revert the commit if you don't want it). But I would recommend to enable it time to time, or even better, make it part of the build/publish process.

---

Closes #????

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/html-aam/pull/287.html" title="Last updated on Jun 1, 2020, 11:31 AM UTC (ba162f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/287/142f6bb...sidvishnoi:ba162f2.html" title="Last updated on Jun 1, 2020, 11:31 AM UTC (ba162f2)">Diff</a>