### PR TITLE
Editorial: link to HTML spec for row/column header definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3506,7 +3506,7 @@
             </tr>
             <tr tabindex="-1" id="el-tfoot">
                 <th><a data-cite="HTML">`tfoot`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
+                <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3514,98 +3514,119 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-th">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element"><code>th</code></a> <span class="el-context">(is neither column header nor row header, and ancestor <a href="https://www.w3.org/TR/html/tabular-data.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-table"><code>table</code></a> role)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-cell"><code>cell</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`th`</a>
+                <span class="el-context">(is neither
+                  <a data-cite="HTML/tables.html#column-header">column header</a>
+                  nor <a data-cite="HTML/tables.html#row-header">row header</a>,
+                  and ancestor <a data-cite="HTML">`table`</a> element has
+                  <a class="core-mapping" href="#role-map-table">`table`</a> role)</span>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-cell">`cell`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-th-gridcell">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element"><code>th</code></a> <span class="el-context">(is neither column header nor row header, and ancestor <a href="https://www.w3.org/TR/html/tabular-data.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-grid"><code>grid</code></a> or <a class="core-mapping" href="#role-map-treegrid"><code>treegrid</code></a> role)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-gridcell"><code>gridcell</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element">`th`</a>
+                <span class="el-context">(is neither
+                  <a data-cite="HTML/tables.html#column-header">column header</a>
+                  nor <a data-cite="HTML/tables.html#row-header">row header</a>,
+                  and ancestor <a data-cite="HTML">`table`</a> element has
+                  <a class="core-mapping" href="#role-map-grid">`grid`</a>
+                  or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)</span>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-th-columnheader">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element"><code>th</code></a> <span class="el-context">(is a column header)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-columnheader"><code>columnheader</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`th`</a>
+                <span class="el-context">(is a <a data-cite="HTML/tables.html#column-header">column header</a>)</span>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-columnheader">`columnheader`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-th-rowheader">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element"><code>th</code></a> <span class="el-context">(is a row header)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-rowheader"><code>rowheader</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`th`</a>
+                <span class="el-context">(is a <a data-cite="HTML/tables.html#row-header">row header</a>)</span>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-rowheader">`rowheader`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-thead">
-                <th><a data-cite="HTML">`thead`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type:</span> <code>Header</code>
-                  </div>
-                </td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`thead`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Header`
+                </div>
+              </td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-time">
-                <th><a data-cite="HTML">`time`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role:</span> <code>IA2_ROLE_TEXT_FRAME</code>
-                  </div>
-                  <div class="objattrs">
-                    <span class="type">Object attributes:</span> <code>xml-roles:time</code>
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces:</span> <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type:</span> `Text`
-                  </div>
-                  <div class="ctrltype">
-                    <span class="type">Localized Control Type:</span> <code>"time"</code>
-                  </div>
-                   <div class="general">Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    <p class="role"><span class="type">Role: </span> `ATK_ROLE_STATIC`</p>
-                  </div>
-                  <div class="objattrs">
-                    <span class="type">Object attributes:</span> <code>xml-roles:time</code>
-                  </div>
-                  <div class="ifaces"> <span class="type">Interfaces: </span> `AtkText`; `AtkHypertext` </div>
-                <p></p></td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole:</span> <code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole:</span> <code>AXTimeGroup</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription:</span> <code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`time`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `IA2_ROLE_TEXT_FRAME`
+                </div>
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `xml-roles:time`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"time"`
+                </div>
+                 <div class="general">Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  <p class="role"><span class="type">Role: </span> `ATK_ROLE_STATIC`</p>
+                </div>
+                <div class="objattrs">
+                  <span class="type">Object attributes:</span> `xml-roles:time`
+                </div>
+                <div class="ifaces"> <span class="type">Interfaces: </span> `AtkText`; `AtkHypertext`</div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXTimeGroup`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-title">
                 <th><a data-cite="HTML">`title`</a></th>
@@ -3617,22 +3638,22 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-tr">
-                <th><a data-cite="HTML">`tr`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-row"><code>row</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Generally not mapped. If the element must be included per Core-AAM Section 5.1.2, map as <code>Group</code>.</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`tr`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-row"><code>row</code></a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Generally not mapped. If the element must be included per Core-AAM Section 5.1.2, map as <code>Group</code>.</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-track">
-                <th><a data-cite="HTML">`track`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`track`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-u">
                 <th><a data-cite="HTML">`u`</a></th>
@@ -4582,16 +4603,16 @@
                 </td>
                 <td class="atk">
                   <div class="general">
-                    Links the cell to its row and column header cells
+                    Links the cell to its row and <a data-cite="HTML/tables.html#column-header">column header</a> cells
                     (note, only one row and one column header cells can be exposed because of API restrictions).
-                    See <code>atk_table_get_row_header</code> and <code>atk_table_get_column_header</code>.
+                    See `atk_table_get_row_header` and `atk_table_get_column_header`.
                   </div>
                 </td>
-                <td class="ax">Expose via <code>AXColumnHeaderUIElements</code> and <code>AXRowHeaderUIElements</code></td>
+                <td class="ax">Expose via `AXColumnHeaderUIElements` and `AXRowHeaderUIElements`</td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-height">
-                <th><code>height</code></th>
+                <th>`height`</th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/semantics-scripting.html#element-attrdef-canvas-height"><code>canvas</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-height"><code>embed</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-height"><code>iframe</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-height"><code>img</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-height">`input`</a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-height"><code>object</code></a>; <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-media-height"><code>video</code></a></td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2">


### PR DESCRIPTION
closes #297


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/301.html" title="Last updated on Aug 11, 2020, 12:29 PM UTC (6a87374)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/301/0e0db26...6a87374.html" title="Last updated on Aug 11, 2020, 12:29 PM UTC (6a87374)">Diff</a>