### PR TITLE
Give column group headers a role of columnheader

### DIFF
--- a/index.html
+++ b/index.html
@@ -3514,9 +3514,11 @@
             <tr tabindex="-1" id="el-th">
               <th>
                 <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is neither
-                  <a data-cite="HTML/tables.html#column-header">column header</a>
-                  nor <a data-cite="HTML/tables.html#row-header">row header</a>,
+                <span class="el-context">(is not a
+                  <a data-cite="HTML/tables.html#column-header">column header</a>,
+                  <a data-cite="HTML/tables.html#row-header">row header</a>,
+                  <a data-cite="HTML/tables.html#column-group-header">column group header</a> or 
+                  <a data-cite="HTML/tables.html#row-group-header">row group header</a>,
                   and ancestor <a data-cite="HTML">`table`</a> element has
                   <a class="core-mapping" href="#role-map-table">`table`</a> role)</span>
               </th>
@@ -3530,9 +3532,11 @@
             <tr tabindex="-1" id="el-th-gridcell">
               <th>
                 <a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element">`th`</a>
-                <span class="el-context">(is neither
-                  <a data-cite="HTML/tables.html#column-header">column header</a>
-                  nor <a data-cite="HTML/tables.html#row-header">row header</a>,
+                <span class="el-context">(is not a
+                  <a data-cite="HTML/tables.html#column-header">column header</a>,
+                  <a data-cite="HTML/tables.html#row-header">row header</a>,
+                  <a data-cite="HTML/tables.html#column-group-header">column group header</a> or 
+                  <a data-cite="HTML/tables.html#row-group-header">row group header</a>,
                   and ancestor <a data-cite="HTML">`table`</a> element has
                   <a class="core-mapping" href="#role-map-grid">`grid`</a>
                   or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)</span>
@@ -3547,7 +3551,7 @@
             <tr tabindex="-1" id="el-th-columnheader">
               <th>
                 <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is a <a data-cite="HTML/tables.html#column-header">column header</a>)</span>
+                <span class="el-context">(is a <a data-cite="HTML/tables.html#column-header">column header</a> or <a data-cite="HTML/tables.html#column-group-header">column group header</a>)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-columnheader">`columnheader`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3559,7 +3563,7 @@
             <tr tabindex="-1" id="el-th-rowheader">
               <th>
                 <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is a <a data-cite="HTML/tables.html#row-header">row header</a>)</span>
+                <span class="el-context">(is a <a data-cite="HTML/tables.html#row-header">row header</a> or <a data-cite="HTML/tables.html#row-group-header">row group header</a>)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-rowheader">`rowheader`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>


### PR DESCRIPTION
The current spec always gives a `<th scope="colgroup">` element a role of `cell` or `gridcell`. It seems that it `columnheader` would be more appropriate.

Chrome and Firefox already exhibit this behaviour.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexLloyd0/html-aam/pull/313.html" title="Last updated on Apr 16, 2021, 12:44 PM UTC (1aa722e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/313/76f3670...AlexLloyd0:1aa722e.html" title="Last updated on Apr 16, 2021, 12:44 PM UTC (1aa722e)">Diff</a>