### PR TITLE
Fix link to HTML button, option, li and param value attributes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5944,7 +5944,10 @@
             </tr>
             <tr tabindex="-1" id="att-value-button">
                 <th><code>value</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-button-value">`button`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-option-value"><code>option</code></a></td>
+                <td class="elements">
+                  <a data-cite="html/form-elements.html#attr-button-value">`button`</a>;
+                  <a data-cite="html/form-elements.html#attr-option-value">`option`</a>
+                </td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>
@@ -5993,7 +5996,9 @@
             </tr>
             <tr tabindex="-1" id="att-value-li">
                 <th><code>value</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/grouping-content.html#element-attrdef-li-value"><code>li</code></a></td>
+                <td class="elements">
+                  <a data-cite="html/grouping-content.html#attr-li-value">`li`</a>
+                </td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2">
                   <div class="general">
@@ -6013,7 +6018,7 @@
                 <td class="ax">
                     <div class="general">Exposed as <code>AXValue: &lt;value&gt;</code> with accessible object:</div>
                     <div class="role">
-                        <span class="type">AXRole:</span> <code>AXLlistMarker</code>
+                        <span class="type">AXRole:</span> <code>AXListMarker</code>
                     </div>
                     <div class="subrole">
                         <span class="type">AXSubrole:</span> `(nil)`
@@ -6055,7 +6060,9 @@
             </tr>
             <tr tabindex="-1" id="att-value-param">
                 <th><code>value</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-param-value"><code>param</code></a></td>
+                <td class="elements">
+                  <a data-cite="html/iframe-embed-object.html#attr-param-value">`param`</a>
+                </td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
                 <td class="uia"><div class="general">Not mapped</div></td>


### PR DESCRIPTION
Also fix typo AXLlistMarker -> AXListMarker.

No corresponding issue.

(Note that this ensures that all of the "value attribute" links work.
There are still broken links to other html attribute definitions, but those can be fixed on another day in another PR... :) )


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/315.html" title="Last updated on Mar 20, 2021, 3:28 PM UTC (44fe2b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/315/e84726e...44fe2b3.html" title="Last updated on Mar 20, 2021, 3:28 PM UTC (44fe2b3)">Diff</a>