### PR TITLE
clarify hidden attribute mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -4633,14 +4633,20 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-hidden">
-                <th><code>hidden</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/editing.html#the-hidden-attribute">HTML elements</a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaHiddenTrue"><code>aria-hidden="true"</code></a> if the element is <code>display: none</code>, or if the element is <code>visibility: hidden</code>. If the element is no longer <code>display: none</code> or <code>visibility: hidden</code> then it does not map.</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="html/interaction.html#the-hidden-attribute">`hidden`</a>
+              </th>
+              <td class="elements">
+                <a data-cite="html/infrastructure.html#html-elements">HTML elements</a>
+              </td>
+              <td class="aria">
+                <a class="core-mapping" href="#ariaHiddenTrue">`aria-hidden="true"`</a> if the element retains its user agent default styling of `display: none`. Otherwise, if no other method for hiding the content is used (e.g., `visibility: hidden`) then it is not mapped.
+              </td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-high">
               <th>`high`</th>


### PR DESCRIPTION
Closes #319

rewords manner in which `hidden` will continue to map to `aria-hidden=true`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/320.html" title="Last updated on Apr 12, 2021, 4:10 PM UTC (1744f52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/320/83a9fee...1744f52.html" title="Last updated on Apr 12, 2021, 4:10 PM UTC (1744f52)">Diff</a>