### PR TITLE
add faces references to attributes table rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -4450,7 +4450,8 @@
                 <a data-cite="html/form-elements.html#attr-optgroup-disabled">`optgroup`</a>;
                 <a data-cite="html/form-elements.html#attr-option-disabled">`option`</a>;
                 <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`select`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`textarea`</a>
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`textarea`</a>;
+                <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
               </td>
               <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a></td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -4547,25 +4548,35 @@
                 <td class="atk">
                   <div class="relations">
                     <span class="type">Relations: </span>
-                    <code>ATK_RELATION_CONTROLLED_BY</code> with an element pointed by the attribute.
-                    Paired element exposes <code>ATK_RELATION_CONTROLLER_FOR</code> relation.
+                    `ATK_RELATION_CONTROLLED_BY` with an element pointed by the attribute.
+                    Paired element exposes `ATK_RELATION_CONTROLLER_FOR` relation.
                   </div>
                 </td>
                 <td class="ax"><div class="general">Not mapped</div></td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-form">
-                <th><code>form</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form">`button`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form"><code>fieldset</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form">`input`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form">`label`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form"><code>object</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form"><code>output</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-form"><code>textarea</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`form`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`button`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`fieldset`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`input`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`label`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`object`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`output`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`select`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`textarea`</a>;
+                <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-formaction">
-                <th><code>formaction</code></th>
+                <th>`formaction`</th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-submitbuttonelements-formaction">`button`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-submitbuttonelements-formaction">`input`</a></td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
@@ -4575,7 +4586,7 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-formenctype">
-                <th><code>formenctype</code></th>
+                <th>`formenctype`</th>
                 <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-submitbuttonelements-formenctype">`button`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-submitbuttonelements-formenctype">`input`</a></td>
                 <td class="aria"><div class="general">Not mapped</div></td>
                 <td class="ia2"><div class="general">Not mapped</div></td>
@@ -4657,8 +4668,10 @@
                     Defines an accessible object's height (<code>atk_component_get_size</code>)
                   </div>
                 </td>
-                <td class="ax"><p class="general">Defines an accessible object's height </p>
-                <p class="general">(<code>AXSize</code> property)</p></td>
+                <td class="ax">
+                  <p class="general">Defines an accessible object's height </p>
+                  <p class="general">(<code>AXSize</code> property)</p>
+                </td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-hidden">
@@ -5071,14 +5084,22 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-name">
-                <th><code>name</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-name">`button`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-name"><code>fieldset</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-name">`input`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-name"><code>output</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-name"><code>select</code></a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-formelements-name"><code>textarea</code></a></td>
-                <td class="aria"><div class="general">Not mapped</div></td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th>`name`</th>
+              <td class="elements">
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`button`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`fieldset`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`input`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`output`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`select`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`textarea`</a>;
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">form-associated custom element</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-name-form">
                 <th><code>name</code></th>
@@ -5291,14 +5312,18 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-readonly">
-                <th><code>readonly</code></th>
-                <td class="elements"><a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-readonly">`input`</a>; <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-textarea-readonly"><code>textarea</code></a></td>
-                <td class="aria"><a class="core-mapping" href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a></td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>`readonly`</th>
+              <td class="elements">
+                <a data-cite="html/input.html#attr-input-readonly">`input`</a>;
+                <a data-cite="html/form-elements.html#attr-textarea-readonly">`textarea`</a>
+                <a data-cite="html/custom-elements.html#attr-face-readonly">form-associated custom elements</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaReadonlyTrue"><code>aria-readonly="true"</code></a></td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-referrerpolicy">
               <th><code>referrerpolicy</code></th>

--- a/index.html
+++ b/index.html
@@ -6909,6 +6909,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
+          <li>12-May-2021: Add FACES references to attributes table - `readonly`, `name`, `form`, `disabled`. See <a href="https://github.com/w3c/html-aam/issues/257">Issue 257</a>.</li>
           <li>12-Dec-2019: Adds `hgroup`, `slot`, autonomous custom element and form associated custom element. See <a href="https://github.com/w3c/html-aam/issues/189">GitHub issue #189</a>.</li>
           <li>26-Nov-2019: Updates mappings for `disabled`, `scope`, `spellcheck`, `tabindex` to point to WAI-ARIA.  Adds AX `pattern`, `reversed`, `rows`, `size`, `span`, `src`, `start`, `step`, `type` attribute mappings. Adds `min-length`, `ping`, `playsinline`, `referrerpolicy`, `sizes`, `srcset`, `data[value]` attribute mappings. See <a href="https://github.com/w3c/html-aam/pull/245">GitHub pull request #245</a>.</li>
         </ul>


### PR DESCRIPTION
- `readonly`
- `name`
- `form`
- `disabled`

This addresses the above attributes that have [faces as a referenced element in HTML's attributes table](https://html.spec.whatwg.org/multipage/indices.html#attributes-3)

per #257, there are additional attributes that need to be spec'd for faces as well - for instance:
- autocomplete
- checked
- max
- min
- placeholder
- required
- selected


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/321.html" title="Last updated on May 12, 2021, 2:48 PM UTC (f64e464)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/321/e60e73e...f64e464.html" title="Last updated on May 12, 2021, 2:48 PM UTC (f64e464)">Diff</a>