### PR TITLE
Match core aam

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,9 @@
               <th>
                 <a data-cite="HTML">`blockquote`</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-blockquote">`blockquote`</a> role</td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-blockquote">`blockquote`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -736,53 +738,11 @@
               <th>
                 <a data-cite="HTML">`caption`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_CAPTION`
-                </div>
-                <div class="states">
-                  <span class="type">States:</span> `STATE_SYSTEM_READONLY`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `IA2_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="properties">
-                  <span class="type">Other properties:</span> The `LabeledBy` property for the parent <a href="#el-table">`table`</a> element points to the UIA element for the `caption` element.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CAPTION`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-caption">`caption`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-cite">
@@ -822,7 +782,9 @@
               <th>
                 <a data-cite="HTML">`code`</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-code">`code`</a> role</td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-code">`code`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>

--- a/index.html
+++ b/index.html
@@ -1446,7 +1446,9 @@
             </tr>
             <tr tabindex="-1" id="el-img-empty-alt">
               <th>
-                <a data-cite="html">`img`</a> <span class="el-context">(<a data-cite="html/embedded-content.html#attr-img-alt">`alt`</a> attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span>
+                <a data-cite="html">`img`</a>
+                <span class="el-context">(<a data-cite="html/embedded-content.html#attr-img-alt">`alt`</a>
+                attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span>
               </th>
               <td class="aria">
                 <div class="role">
@@ -1464,7 +1466,8 @@
             </tr>
             <tr tabindex="-1" id="el-input-button">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#button-state-typebutton">Button</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#button-state-(type=button)">Button</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-button">`button`</a> role
@@ -1476,59 +1479,73 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-input-checkbox">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#checkbox-state-typecheckbox">Checkbox</a> state)</span></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-checkbox"><code>checkbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedMixed"><code>aria-checked</code></a> state set to "mixed" if the element's <code>indeterminate</code> IDL attribute is true, or "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span>
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-checkbox">`checkbox`</a> role, with the
+                <a class="core-mapping" href="#ariaCheckedMixed">`aria-checked`</a> state set to "mixed" if the element's
+                <a data-cite="html/input.html#dom-input-indeterminate">`indeterminate` IDL attribute</a> is true, or "true" if the element's
+                <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-input-color">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#color-state-typecolor">Color</a> state)</span></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">If implemented as a textbox:</div>
-                  <div class="role"><span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`</div>
-                  <div class="general">If implemented as a color picker:</div>
-                  <div class="role"><span class="type">Roles:</span> <code>IA2_ROLE_COLOR_CHOOSER</code></div>
-                </td>
-                <td class="uia">
-                  <div class="general">If implemented as a textbox:</div>
-                  <div class="ctrltype"><span class="type">Control Type:</span> <code>Edit</code></div>
-                  <div class="properties"><span class="type">Localized Control Type: </span> "edit"</div>
-                  <div class="general">If implemented as a color picker:</div>
-                  <div class="ctrltype"><span class="type">Control Type:</span> `button`</div>
-                  <div class="properties"><span class="type">Localized Control Type: </span> "Color Picker"</div>
-                  <!-- <div class="ctrlpattern"><span class="type">Control Pattern:</span> <code>Selection</code> for the container and <code>SelectionItem</code> for each color choice</div> -->
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    If implemented as a button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-button">`button`</a>.
-                  </div>
-                  <div class="general">
-                    If implemented as a textbox, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="general">If implemented as a textbox:</div>
-                    <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
-                    <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
-                    <div class="roledesc"><span class="type">AXRoleDescription:</span> <code>"text field"</code></div>
-                    <div class="general">If implemented as a color picker:</div>
-                    <div class="role"><span class="type">AXRole:</span> <code>AXColorWell</code></div>
-                    <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
-                    <div class="roledesc"><span class="type">AXRoleDescription:</span> <code>"color well"</code></div>
-                </td>
-                <td class="comments">
-                  <div class="general">
-                    If implemented as a color picker, any UI controls presented for selecting a color are exposed in the <a class="termref">accessibility tree</a>, associated with the `input` element, and mapped as appropriate for the type of control (e.g. button or slider).
-                  </div>
-                </td>
+              <th>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                <a data-cite="html/input.html#color-state-(type=color)">Color</a> state)</span>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">If implemented as a textbox:</div>
+                <div class="role"><span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`</div>
+                <div class="general">If implemented as a color picker:</div>
+                <div class="role"><span class="type">Roles:</span> `IA2_ROLE_COLOR_CHOOSER`</div>
+              </td>
+              <td class="uia">
+                <div class="general">If implemented as a textbox:</div>
+                <div class="ctrltype"><span class="type">Control Type:</span> `Edit`</div>
+                <div class="properties"><span class="type">Localized Control Type: </span> "edit"</div>
+                <div class="general">If implemented as a color picker:</div>
+                <div class="ctrltype"><span class="type">Control Type:</span> `button`</div>
+                <div class="properties"><span class="type">Localized Control Type: </span> "Color Picker"</div>
+                <!-- <div class="ctrlpattern"><span class="type">Control Pattern:</span> `Selection` for the container and `SelectionItem` for each color choice</div> -->
+              </td>
+              <td class="atk">
+                <div class="general">
+                  If implemented as a button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-button">`button`</a>.
+                </div>
+                <div class="general">
+                  If implemented as a textbox, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="general">If implemented as a textbox:</div>
+                <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
+                <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
+                <div class="roledesc"><span class="type">AXRoleDescription:</span> `"text field"`</div>
+                <div class="general">If implemented as a color picker:</div>
+                <div class="role"><span class="type">AXRole:</span> `AXColorWell`</div>
+                <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
+                <div class="roledesc"><span class="type">AXRoleDescription:</span> `"color well"`</div>
+              </td>
+              <td class="comments">
+                <div class="general">
+                  If implemented as a color picker, any UI controls presented for selecting a color are exposed in the
+                  <a class="termref">accessibility tree</a>, associated with the `input` element, and mapped as appropriate for the type of control (e.g. button or slider).
+                </div>
+              </td>
             </tr>
             <tr tabindex="-1" id="el-input-date">
                 <th>
-                  <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#date-state-typedate">Date</a> state)</span>
+                  <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                    <a data-cite="html/input.html#date-state-(type=date)">Date</a> state)</span>
               </th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
@@ -1600,17 +1617,20 @@
                 <td class="comments"></td>
             </tr>-->
             <tr tabindex="-1" id="el-input-email">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#email-state-typeemail">E-mail</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span></th>
+                <th>
+                  <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                    <a data-cite="html/input.html#email-state-(type=email)">E-mail</a> state with no <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
+                </th>
                 <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
                 <td class="ia2">
                   <div class="general">Use WAI-ARIA mapping</div>
                   <div class="objattrs"> <span class="type">Object attributes: </span> <code>text-input-type:email</code> </div>
                 </td>
                 <td class="uia">
-                    <div class="general">Use WAI-ARIA mapping</div>
-                    <div class="ctrltype">
-                        <span class="type">Localized Control Type:</span> <code>"email"</code>
-                    </div>
+                  <div class="general">Use WAI-ARIA mapping</div>
+                  <div class="ctrltype">
+                    <span class="type">Localized Control Type:</span> `"email"`
+                  </div>
                 </td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1618,7 +1638,8 @@
             </tr>
             <tr tabindex="-1" id="el-input-file">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#file-upload-state-typefile">File Upload</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#file-upload-state-(type=file)">File Upload</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1672,7 +1693,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-hidden">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#hidden-state-typehidden">Hidden</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#hidden-state-(type=hidden)">Hidden</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2"><div class="general">Not mapped</div></td>
@@ -1683,7 +1706,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-image">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#image-button-state-typeimage">Image Button</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#image-button-state-(type=image)">Image Button</a> state)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-button">`button`</a> role </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1694,12 +1719,14 @@
             </tr>
             <tr tabindex="-1" id="el-input-datetime-local">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">Local Date and Time</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
                 <div class="role">
-                  <span class="type">Role:</span> <code>IA2_ROLE_DATE_EDITOR</code>
+                  <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
                 </div>
               </td>
               <td class="uia">
@@ -1727,7 +1754,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-month">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#month-state-typemonth">Month</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#month-state-(type=month)">Month</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1760,17 +1789,21 @@
             </tr>
             <tr tabindex="-1" id="el-input-number">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#number-state-typenumber">Number</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#number-state-(type=number)">Number</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a> role
               </td>
               <td class="ia2">
                 <div class="general">
-                  If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.
+                  If implemented as a spin button, use WAI-ARIA mapping for
+                  <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.
                 </div>
                 <div class="general">
-                  If implemented as a text input, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
+                  If implemented as a text input, use WAI-ARIA mapping for
+                  <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
                 </div>
                 <div class="objattrs">
                   <span class="type">Object attributes:</span> `text-input-type:number`
@@ -1802,7 +1835,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-password">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#password-state-typepassword">Password</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#password-state-(type=password)">Password</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1843,10 +1878,17 @@
             </tr>
             <tr tabindex="-1" id="el-input-radio">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-state-typeradio">Radio Button</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#radio-button-state-(type=radio)">Radio Button</a> state)</span>
               </th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-radio">`radio`</a> role, with the <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> state set to "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise. With <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `type=radio input` elements within the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-group">radio button group</a>  and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the elements position within the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-group">radio button group</a>.
+                <a class="core-mapping" href="#role-map-radio">`radio`</a> role, with the
+                <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> state set to "true" if the element's
+                <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise.
+                With <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `type=radio input` elements within the
+                <a data-cite="html/input.html#radio-button-group">radio button group</a>
+                and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the elements position within the <a data-cite="html/input.html#radio-button-group">radio button group</a>.
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1856,7 +1898,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-range">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#range-state-typerange">Range</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#range-state-(type=range)">Range</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-slider">`slider`</a> role
@@ -1869,7 +1913,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-reset">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#reset-button-state-typereset">Reset Button</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#reset-button-state-(type=reset)">Reset Button</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-button">`button`</a> role
@@ -1882,7 +1928,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-search">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Search</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element" title="concept-input-list">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Search</a> state with no <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-searchbox">`searchbox`</a> role
@@ -1908,7 +1956,10 @@
             </tr>
             <tr tabindex="-1" id="el-input-tel">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#telephone-state-typetel">Telephone</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#telephone-state-(type=tel)">Telephone</a> state with no
+                  <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
@@ -1931,7 +1982,10 @@
             </tr>
             <tr tabindex="-1" id="el-input-text">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Text</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Text</a> state with no
+                  <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2017,7 +2071,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-url">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#url-state-typeurl">URL</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element" title="concept-input-list">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#url-state-(type=url)">URL</a> state with no <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
               <td class="ia2">
@@ -2036,7 +2092,9 @@
             </tr>
             <tr tabindex="-1" id="el-input-week">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#week-state-typeweek">Week</a> state)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#week-state-(type=week)">Week</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -2313,18 +2371,21 @@
                   </p>
                 </div>
                 <p>
-                  <span class="objattrs"><span class="type">Object attributes: </span></span><code>xml-roles:mark</code>
+                  <span class="objattrs">
+                    <span class="type">Object attributes:</span>
+                    `xml-roles:mark`
+                  </span>
                 </p>
                 <p>
                   <span class="general">Styles used are mapped to text attributes on the accessible object.</span>
                 </p>
                 <div class="ifaces">
-                  <span class="type">Interfaces: </span> `AtkText`; `AtkHypertext`
+                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
                 <div class="role">
-                  <span class="type">AXRole:</span> <code>AXGroup</code>
+                  <span class="type">AXRole:</span> `AXGroup`
                 </div>
                 <div class="subrole">
                   <span class="type">AXSubrole:</span> `(nil)`
@@ -2337,7 +2398,7 @@
             </tr>
             <tr tabindex="-1" id="el-math">
               <th>
-                <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#mathml">`math`</a>
+                <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-math">`math`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2407,10 +2468,11 @@
                 <td class="ia2">
                   <div class="general">Depends on format of data file. If it contains a plugin then,</div>
                   <div class="role">
-                    <span class="type">Role:</span> <code>IA2_ROLE_EMBEDDED_OBJECT</code>
+                    <span class="type">Role:</span> `IA2_ROLE_EMBEDDED_OBJECT`
                   </div>
                   <div class="states">
-                    <span class="type">States:</span> <code>STATE_SYSTEM_UNAVAILABLE</code> for windowless plugin
+                    <span class="type">States:</span>
+                    `STATE_SYSTEM_UNAVAILABLE` for windowless plugin
                   </div>
                 </td>
                 <td class="uia">
@@ -2422,7 +2484,7 @@
                   </div>
                   <div class="role">
                     <span class="type">Role:</span>
-                    <code>ATK_ROLE_EMBEDDED</code>
+                    `ATK_ROLE_EMBEDDED`
                   </div>
                 </td>
                 <td class="ax">Depends on format of data file.</td>
@@ -2451,7 +2513,9 @@
                 <a data-cite="html">`option`</a> <span class="el-context">(in a <a data-cite="html/form-elements.html#concept-select-option-list">list of options</a> or represents a suggestion in a <a data-cite="html">`datalist`</a>)</span>
               </th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-option">`option`</a> role, with the <a class="core-mapping" href="#ariaSelectedTrue">`aria-selected`</a> state set to "true" if the element's <a data-cite="html/form-elements.html#concept-option-selectedness">selectedness</a> is true, or "false" otherwise.
+                <a class="core-mapping" href="#role-map-option">`option`</a> role, with the
+                <a class="core-mapping" href="#ariaSelectedTrue">`aria-selected`</a> state set to "true" if the element's
+                <a data-cite="html/form-elements.html#concept-option-selectedness">selectedness</a> is true, or "false" otherwise.
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2481,13 +2545,13 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-param">
-                <th><a data-cite="HTML">`param`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`param`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-picture">
               <th><a data-cite="HTML">`picture`</a></th>
@@ -2496,109 +2560,111 @@
               <td class="uia"><div class="general">Not mapped</div></td>
               <td class="atk"><div class="general">Not mapped</div></td>
               <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-pre">
-                <th><a data-cite="HTML">`pre`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles:</span> <code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
-                  </div>
-                  <div class="general">
-                    Styles used are mapped to text attributes on the parent accessible object.
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces:</span>
-                    <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                        <span class="type">Control Type:</span> `Text`
-                  </div>
-                  <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"pre"</code></div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    <code>ATK_ROLE_SECTION</code>
-                  </div>
-                  <div class="general">
-                    Styles used are mapped to text attributes on the accessible object.
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces:</span>
-                    `AtkText`; `AtkHypertext`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`pre`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
+                </div>
+                <div class="general">
+                  Styles used are mapped to text attributes on the parent accessible object.
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span>
+                  `IAccessibleText2`; `IAccessibleHypertext2`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"pre"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span>
+                  `ATK_ROLE_SECTION`
+                </div>
+                <div class="general">
+                  Styles used are mapped to text attributes on the accessible object.
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span>
+                  `AtkText`; `AtkHypertext`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-progress">
-                <th><a data-cite="HTML">`progress`</a></th>
-                <td class="aria">
-                  <a class="core-mapping" href="#role-map-progressbar">`progressbar`</a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a> property set to the current value of the progress bar
-                </td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`progress`</a></th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-progressbar">`progressbar`</a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a> property set to the current value of the progress bar
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-q">
-                <th><a data-cite="HTML">`q`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles:</span>
-                    `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                  </div>
-                  <div class="children">
-                    <span class="type">Children:</span> `ROLE_SYSTEM_TEXT` wrapped by quote marks using `ROLE_SYSTEM_STATICTEXT`
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                        <span class="type">Control Type:</span> `Text`
-                  </div>
-                  <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"q"</code></div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    `ATK_ROLE_STATIC`
-                  </div>
-                  <div class="ifaces">
-                    <span class="type">Interfaces:</span>
-                    `AtkText`; `AtkHypertext`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`q`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Roles:</span>
+                  `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+                </div>
+                <div class="children">
+                  <span class="type">Children:</span> `ROLE_SYSTEM_TEXT` wrapped by quote marks using `ROLE_SYSTEM_STATICTEXT`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"q"`</div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span>
+                  `ATK_ROLE_STATIC`
+                </div>
+                <div class="ifaces">
+                  <span class="type">Interfaces:</span>
+                  `AtkText`; `AtkHypertext`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <!--
               *** Marked as obsolete in HTML. ***
@@ -2653,42 +2719,42 @@
                 <td class="atk">
                   <div class="general">
                     No accessible object. No child elements are
-                    exposed if <a href="#el-ruby"><code>ruby</code></a> is supported by the browser.
+                    exposed if <a href="#el-ruby">`ruby`</a> is supported by the browser.
                   </div>
                 </td>
                 <td class="ax">Not mapped</td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-rt">
-                <th><a data-cite="HTML">`rt`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">
-                    No accessible object. No child elements are exposed if <a href="#el-ruby"><code>ruby</code></a> is supported by the browser.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    No accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object.
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                      <span class="type">AXSubrole:</span> `AXRubyText`
-                  </div>
-                  <div class="roledesc">
-                      <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`rt`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">
+                  No accessible object. No child elements are exposed if <a href="#el-ruby">`ruby`</a> is supported by the browser.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  No accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  No accessible object.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXRubyText`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <!--
               *** Marked as obsolete in HTML. ***
@@ -2837,7 +2903,8 @@
             <tr tabindex="-1" id="el-section">
               <th><a data-cite="HTML">`section`</a></th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an <a class="termref">accessible name</a>.
+                <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an
+                <a class="termref">accessible name</a>.
                 Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a>
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2967,7 +3034,7 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments">
                 <div class="general">
-                  <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs. For instance, <code>display: none</code> or <code>visibility: hidden</code> will remove an element from the accessibility tree and hide its presence from assistive technologies.
+                  <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs. For instance, `display: none` or `visibility: hidden` will remove an element from the accessibility tree and hide its presence from assistive technologies.
                 </div>
               </td>
             </tr>
@@ -3065,7 +3132,11 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-td">
-              <th><a data-cite="HTML">`td`</a> (ancestor <a data-cite="HTML">`table`</a> element has <a class="core-mapping" href="#role-map-table">`table`</a> role)</th>
+              <th>
+                <a data-cite="HTML">`td`</a>
+                (ancestor <a data-cite="HTML">`table`</a> element has
+                <a class="core-mapping" href="#role-map-table">`table`</a> role)
+              </th>
               <td class="aria"><a class="core-mapping" href="#role-map-cell">`cell`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3075,7 +3146,10 @@
             </tr>
             <tr tabindex="-1" id="el-td-gridcell">
               <th>
-                <a data-cite="HTML">`td`</a> (ancestor <a data-cite="HTML">`table`</a> element has <a class="core-mapping" href="#role-map-grid">`grid`</a> or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
+                <a data-cite="HTML">`td`</a>
+                (ancestor <a data-cite="HTML">`table`</a> element has
+                <a class="core-mapping" href="#role-map-grid">`grid`</a> or
+                <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3119,7 +3193,7 @@
                 <span class="el-context">(is not a
                   <a data-cite="HTML/tables.html#column-header">column header</a>,
                   <a data-cite="HTML/tables.html#row-header">row header</a>,
-                  <a data-cite="HTML/tables.html#column-group-header">column group header</a> or 
+                  <a data-cite="HTML/tables.html#column-group-header">column group header</a> or
                   <a data-cite="HTML/tables.html#row-group-header">row group header</a>,
                   and ancestor <a data-cite="HTML">`table`</a> element has
                   <a class="core-mapping" href="#role-map-table">`table`</a> role)
@@ -3138,7 +3212,7 @@
                 <span class="el-context">(is not a
                   <a data-cite="HTML/tables.html#column-header">column header</a>,
                   <a data-cite="HTML/tables.html#row-header">row header</a>,
-                  <a data-cite="HTML/tables.html#column-group-header">column group header</a> or 
+                  <a data-cite="HTML/tables.html#column-group-header">column group header</a> or
                   <a data-cite="HTML/tables.html#row-group-header">row group header</a>,
                   and ancestor <a data-cite="HTML">`table`</a> element has
                   <a class="core-mapping" href="#role-map-grid">`grid`</a>

--- a/index.html
+++ b/index.html
@@ -1476,7 +1476,7 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-input-checkbox">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#checkbox-state-typecheckbox">Checkbox</a> state)</span></th>
+                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#checkbox-state-typecheckbox">Checkbox</a> state)</span></th>
                 <td class="aria"><a class="core-mapping" href="#role-map-checkbox"><code>checkbox</code></a> role, with the <a class="core-mapping" href="#ariaCheckedMixed"><code>aria-checked</code></a> state set to "mixed" if the element's <code>indeterminate</code> IDL attribute is true, or "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise </td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1485,7 +1485,7 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-input-color">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#color-state-typecolor">Color</a> state)</span></th>
+                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#color-state-typecolor">Color</a> state)</span></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
                   <div class="general">If implemented as a textbox:</div>
@@ -1528,7 +1528,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-date">
                 <th>
-                  <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#date-state-typedate">Date</a> state)</span>
+                  <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#date-state-typedate">Date</a> state)</span>
               </th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
@@ -1568,7 +1568,7 @@
                 <td class="comments"></td>
             </tr>
            <!-- <tr tabindex="-1" id="el-input-dateandtime">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span></th>
+                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span></th>
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
                   <div class="role">
@@ -1600,7 +1600,7 @@
                 <td class="comments"></td>
             </tr>-->
             <tr tabindex="-1" id="el-input-email">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#email-state-typeemail">E-mail</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span></th>
+                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#email-state-typeemail">E-mail</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span></th>
                 <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
                 <td class="ia2">
                   <div class="general">Use WAI-ARIA mapping</div>
@@ -1618,7 +1618,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-file">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#file-upload-state-typefile">File Upload</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#file-upload-state-typefile">File Upload</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1672,7 +1672,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-hidden">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#hidden-state-typehidden">Hidden</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#hidden-state-typehidden">Hidden</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2"><div class="general">Not mapped</div></td>
@@ -1683,7 +1683,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-image">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#image-button-state-typeimage">Image Button</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#image-button-state-typeimage">Image Button</a> state)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-button">`button`</a> role </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1694,7 +1694,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-datetime-local">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1727,7 +1727,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-month">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#month-state-typemonth">Month</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#month-state-typemonth">Month</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1760,7 +1760,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-number">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#number-state-typenumber">Number</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#number-state-typenumber">Number</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a> role
@@ -1802,7 +1802,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-password">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#password-state-typepassword">Password</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#password-state-typepassword">Password</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -1843,7 +1843,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-radio">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-state-typeradio">Radio Button</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-state-typeradio">Radio Button</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-radio">`radio`</a> role, with the <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> state set to "true" if the element's <a href="https://www.w3.org/TR/html/sec-forms.html#forms-checkedness">checkedness</a> is true, or "false" otherwise. With <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `type=radio input` elements within the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-group">radio button group</a>  and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the elements position within the <a href="https://www.w3.org/TR/html/sec-forms.html#radio-button-group">radio button group</a>.
@@ -1856,7 +1856,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-range">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#range-state-typerange">Range</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#range-state-typerange">Range</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-slider">`slider`</a> role
@@ -1869,7 +1869,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-reset">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#reset-button-state-typereset">Reset Button</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#reset-button-state-typereset">Reset Button</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-button">`button`</a> role
@@ -1882,7 +1882,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-search">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Search</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element" title="concept-input-list">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Search</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element" title="concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-searchbox">`searchbox`</a> role
@@ -1895,7 +1895,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-submit">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#submit-button-state-typesubmit">Submit Button</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#submit-button-state-typesubmit">Submit Button</a> state)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-button">`button`</a> role
@@ -1908,7 +1908,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-tel">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#telephone-state-typetel">Telephone</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#telephone-state-typetel">Telephone</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
@@ -1931,7 +1931,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-text">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Text</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Text</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1942,15 +1942,24 @@
             </tr>
             <tr tabindex="-1" id="el-input-textetc-autocomplete">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Text</a>, <a href="https://www.w3.org/TR/html/sec-forms.html#text-typetext-state-and-search-state-typesearch">Search</a>, <a href="https://www.w3.org/TR/html/sec-forms.html#telephone-state-typetel">Telephone</a>, <a href="https://www.w3.org/TR/html/sec-forms.html#url-state-typeurl">URL</a>, or <a href="https://www.w3.org/TR/html/sec-forms.html#email-state-typeemail">E-mail</a> states with a <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Text</a>,
+                  <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Search</a>,
+                  <a data-cite="html/input.html#telephone-state-(type=tel)">Telephone</a>,
+                  <a data-cite="html/input.html#url-state-(type=url)">URL</a>, or
+                  <a data-cite="html/input.html#email-state-(type=email)">E-mail</a> states with a
+                  <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-combobox"><code>combobox</code></a> role, with the <a class="core-mapping" href="#ariaOwns"><code>aria-owns</code></a> property set to the same value as the <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-list"><code>list</code></a> attribute
+                <a class="core-mapping" href="#role-map-combobox">`combobox`</a> role, with the
+                <a class="core-mapping" href="#ariaControls">`aria-controls`</a> property set to the same value as the
+                <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
               </td>
               <td class="ia2">
                 <div class="general">Use WAI-ARIA mapping</div>
                 <div class="objattrs">
-                  <span class="type">Object attributes:</span> <code>text-input-type:<em>as per input type</em></code>
+                  <span class="type">Object attributes:</span> `text-input-type:<em>as per input type</em>`
                 </div>
               </td>
               <td class="uia">
@@ -1964,7 +1973,11 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-input-time">
-              <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#time-state-typetime">Time</a> state)</span></th>
+              <th>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                  <a data-cite="html/input.html#time-state-(type=time)">Time</a> state)</span>
+              </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
                 <div class="role">
@@ -2004,7 +2017,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-url">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#url-state-typeurl">URL</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element" title="concept-input-list">suggestions source element</a>)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#url-state-typeurl">URL</a> state with no <a href="https://www.w3.org/TR/html/sec-forms.html#suggestions-source-element" title="concept-input-list">suggestions source element</a>)</span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
               <td class="ia2">
@@ -2023,7 +2036,7 @@
             </tr>
             <tr tabindex="-1" id="el-input-week">
               <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#states-of-the-type-attribute">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#week-state-typeweek">Week</a> state)</span>
+                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#week-state-typeweek">Week</a> state)</span>
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">

--- a/index.html
+++ b/index.html
@@ -544,8 +544,11 @@
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
-                <div class="general">
-                  No accessible object. May affect on "writing-mode" text attribute on its text container.
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`
+                </div>
+                <div class="properties">
+                  <span class="type">Text attributes:</span> `writing-mode` on the text container
                 </div>
               </td>
               <td class="uia">
@@ -554,11 +557,21 @@
                 </div>
               </td>
               <td class="atk">
-                <div class="general">
-                  No accessible object. May affect on "writing-mode" text attribute on its text container.
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
                 </div>
               </td>
-              <td class="ax"></td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-bdo">
@@ -580,8 +593,11 @@
                 </div>
               </td>
               <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as "writing-mode" text attribute on its text container.
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
+                </div>
+                <div>
+                  Exposed as "writing-mode" text attribute on its text container.
                 </div>
               </td>
               <td class="ax">
@@ -601,43 +617,11 @@
               <th>
                 <a data-cite="HTML">`blockquote`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"blockquote"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_BLOCK_QUOTE`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-blockquote">`blockquote`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-body">
@@ -706,7 +690,11 @@
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
+              <td class="comments">
+                A `button`'s mapping will change if the
+                <a class="core-mapping" href="role-map-button-pressed">`aria-pressed`</a> and
+                <a class="core-mapping" href="role-map-button-haspopup">`aria-haspopup`</a> attributes are declared.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-canvas">
               <th>
@@ -995,48 +983,11 @@
               <th>
                 <a data-cite="HTML">`div`</a>
               </th>
-              <td class="aria">
-                No corresponding role
-              </td>
-              <td class="ia2">
-                <div class="general">
-                  May not have an accessible object if has no semantic meaning. Otherwise,
-                </div>
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  May not have an accessible object if has no semantic meaning. Otherwise,
-                </div>
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_SECTION`
-                </div>
-                 <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-dl">
@@ -1092,33 +1043,11 @@
               <th>
                 <a data-cite="HTML">`em`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. Styles used are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Styles used are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-emphasis">`emphasis`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-embed">
@@ -1497,11 +1426,11 @@
               <th>
                 <a data-cite="HTML">`hgroup`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-hr">
@@ -4584,8 +4513,10 @@
                     Defines an accessible object's height (<code>atk_component_get_size</code>)
                   </div>
                 </td>
-                <td class="ax"><p class="general">Defines an accessible object's height </p>
-                <p class="general">(<code>AXSize</code> property)</p></td>
+                <td class="ax">
+                  <p class="general">Defines an accessible object's height </p>
+                  <p class="general">(<code>AXSize</code> property)</p>
+                </td>
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-hidden">

--- a/index.html
+++ b/index.html
@@ -232,26 +232,26 @@
             <li>Elements mapped to the `Text` Control Type are not generally represented as <a class="termref" data-lt="accessible object">accessible objects</a> in the <a class="termref">accessibility tree</a>, but are just part of the `Text` Control Pattern implemented for the whole HTML document. However, if they have any `aria-` attributes or an explicit `tabindex` specified, elements mapped to the `Text` Control Type will be represented as <a class="termref" data-lt="accessible object">accessible objects</a> in the <a class="termref">accessibility tree</a>.</li>
           </ul>
         </li>
-    		<li><strong>AXAPI:</strong>
+        <li><strong>AXAPI:</strong>
           <ul>
             <li>User agents should return a user-presentable, localized string value for the Mac Accessibility AXRoleDescription.</li>
           </ul>
         </li>
-    	</ul>
-    	<div class="table-container">
-      	<table class="map-table elements" id="element-mapping-table">
-      		<caption>Mappings of HTML elements to platform <a class="termref">accessibility APIs</a>: ARIA, MSAA + UIA Express, MSAA + IAccessible2, UIA, ATK, and AX</caption>
-      		<thead>
-      			<tr>
-      				<th>Element</th>
-      				<th>[[wai-aria-1.1]]</th>
-      				<th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      </ul>
+      <div class="table-container">
+        <table class="map-table elements" id="element-mapping-table">
+          <caption>Mappings of HTML elements to platform <a class="termref">accessibility APIs</a>: ARIA, MSAA + UIA Express, MSAA + IAccessible2, UIA, ATK, and AX</caption>
+          <thead>
+            <tr>
+              <th>Element</th>
+              <th>[[wai-aria-1.1]]</th>
+              <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
-      				<th><a href="https://developer.gnome.org/atk/stable/">ATK</a></th>
-      				<th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
-      				<th>Comments</th>
-      			</tr>
-      		</thead>
+              <th><a href="https://developer.gnome.org/atk/stable/">ATK</a></th>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <th>Comments</th>
+            </tr>
+          </thead>
           <tbody>
             <tr tabindex="-1" id="el-a">
               <th>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
       // ED pointing to latest draft due to ED links not
       // appropriately mapping on the core-aam spec.
       coreMappingURLs: {
-        "ED":   "https://www.w3.org/TR/core-aam-1.1/",
+        "ED":   "https://w3c.github.io/core-aam/",
         "WD":   "https://www.w3.org/TR/core-aam-1.1/",
         "FPWD": "https://www.w3.org/TR/core-aam-1.1/",
         "REC":  "https://www.w3.org/TR/wai-aria-implementation/"
@@ -258,7 +258,9 @@
                 <a data-cite="HTML">`a`</a>
                 <span class="el-context">(represents a <a data-cite="html">hyperlink</a>)</span>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-link">`link`</a> role </td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-link">`link`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -270,14 +272,12 @@
                 <a data-cite="HTML">`a`</a>
                 <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
               </th>
-              <td class="aria">No corresponding role</td>
+              <td class="aria">
+                No corresponding role
+              </td>
               <td class="ia2">
                 <div class="role">
                   <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleHyperlink`; `IAccessibleText2`; `IAccessibleHypertext2`;
                 </div>
               </td>
               <td class="uia">
@@ -287,12 +287,7 @@
               </td>
               <td class="atk">
                 <div class="role">
-                  <span class="type">Role:</span>
-                  `ATK_ROLE_STATIC`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `AtkText`; `AtkHypertext`
+                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
                 </div>
               </td>
               <td class="ax">
@@ -310,7 +305,9 @@
             </tr>
             <tr tabindex="-1" id="el-abbr">
               <th><a data-cite="HTML">`abbr`</a></th>
-              <td class="aria">No corresponding role</td>
+              <td class="aria">
+                No corresponding role
+              </td>
               <td class="ia2">
                 <div class="role">
                   <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
@@ -356,41 +353,13 @@
             </tr>
             <tr tabindex="-1" id="el-address">
               <th><a data-cite="HTML">`address`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span>
-                  `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
+              <td class="aria">
+                <div><a class="core-mapping" href="#role-map-generic">`generic`</a> role.</div>
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_SECTION`
-                </div>
-                 <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div> </td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-area">
@@ -510,12 +479,20 @@
               <th>
                 <a data-cite="HTML">autonomous custom element</a>
               </th>
-              <td class="aria">If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, no corresponding role.</td>
+              <td class="aria">
+                If the author assigned a conforming ARIA role using the `role` attribute
+                <!-- , or using the custom element's <a data-cite="html/custom-elements.html#the-elementinternals-interface">`elementInternals`</a>,  -->
+                map to that role. Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
+              <td class="comments">
+                <!-- <p class="warning">
+                  The declaring of roles by a custom element's <a data-cite="html/custom-elements.html#the-elementinternals-interface">`elementInternals`</a> is not currently supported.
+                </p> -->
+              </td>
             </tr>
             <tr tabindex="-1" id="el-b">
               <th>
@@ -523,18 +500,18 @@
               </th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
-                <div class="general">
-                  No accessible object. Exposed as "font-weight" text attribute on the text container. The value depends on the platform.
+                <div class="role">
+                  <span class="type">Role:</span> ` ROLE_SYSTEM_STATICTEXT`
                 </div>
               </td>
               <td class="uia">
-                <div class="general">
-                  No accessible object. Exposed by the `FontWeight` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
                 </div>
               </td>
               <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as "font-weight" text attribute on the text container. The value depends on the platform.
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
                 </div>
               </td>
               <td class="ax">
@@ -548,7 +525,7 @@
                   <span class="type">AXRoleDescription:</span> `"group"`
                 </div>
               </td>
-              <td class="comments"></td>
+              <td class="comments">Can be exposed as "font-weight" text attribute on the text container. The value depends on the platform.</td>
             </tr>
             <tr tabindex="-1" id="el-base">
               <th>
@@ -857,33 +834,11 @@
               <th>
                 <a data-cite="HTML">`code`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. Styles used are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Styles used are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXCodeStyleGroup`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-code">`code`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-col">
@@ -964,39 +919,11 @@
               <th>
                 <a data-cite="HTML">`del`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_CONTENT_DELETION`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"del"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CONTENT_DELETION`
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `xml-roles:deletion`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXDeleteStyleGroup`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-deletion">`deletion`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-details">

--- a/index.html
+++ b/index.html
@@ -525,7 +525,9 @@
                   <span class="type">AXRoleDescription:</span> `"group"`
                 </div>
               </td>
-              <td class="comments">Can be exposed as "font-weight" text attribute on the text container. The value depends on the platform.</td>
+              <td class="comments">
+                Can be exposed as "font-weight" text attribute on the text container. The value depends on the platform.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-base">
               <th>
@@ -945,7 +947,9 @@
               <th>
                 <a data-cite="HTML">`div`</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1005,7 +1009,9 @@
               <th>
                 <a data-cite="HTML">`em`</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-emphasis">`emphasis`</a> role</td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-emphasis">`emphasis`</a> role
+              </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -1085,46 +1091,24 @@
               <th>
                 <a data-cite="HTML">`figcaption`</a>
               </th>
-              <td class="aria">No corresponding role</td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-caption">`caption`</a> role
+              </td>
               <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_CAPTION`
-                </div>
+                <div class="general">Use WAI-ARIA mapping</div>
                 <div class="relations">
                   <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-              </td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CAPTION`
-                </div>
+                <div class="general">Use WAI-ARIA mapping</div>
                 <div class="relations">
                   <span class="type">Relations:</span>
                   `ATK_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
               </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-figure">
@@ -1135,24 +1119,16 @@
                 <a class="core-mapping" href="#role-map-figure">`figure`</a> role
               </td>
               <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
+                <div class="general">Use WAI-ARIA mapping</div>
                 <div class="relations">
                   <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
                 </div>
               </td>
               <td class="uia">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="general">
-                  Accessible name derived from `figcaption` according to the <a href="#figure-element-accessible-name-computation">`figure` Element Accessible Name Computation</a>
-                </div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
               <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping</div>
+                <div class="general">Use WAI-ARIA mapping</div>
                 <div class="name">
                   <span class="type">Name:</span> related <a href="#el-figcaption">`figcaption`</a> content
                 </div>
@@ -1161,12 +1137,11 @@
                 </div>
               </td>
               <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="subrole"></div>
+                <div class="general">Use WAI-ARIA mapping</div>
               </td>
-              <td class="comments"></td>
+              <td class="comments">
+                Accessible name derived from `figcaption` according to the <a href="#figure-element-accessible-name-computation">`figure` Element Accessible Name Computation</a>
+              </td>
             </tr>
             <tr tabindex="-1" id="el-footer-ancestorbody">
               <th>

--- a/index.html
+++ b/index.html
@@ -354,7 +354,8 @@
             <tr tabindex="-1" id="el-address">
               <th><a data-cite="HTML">`address`</a></th>
               <td class="aria">
-                <div><a class="core-mapping" href="#role-map-generic">`generic`</a> role.</div>
+                <div>If provided an <a class="termref">accessible name</a> <a class="core-mapping" href="#role-map-group">`group`</a> role.</div>
+                <div>Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</div>
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div> </td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -697,7 +698,7 @@
               <td class="comments">
                 A `button`'s mapping will change if the
                 <a class="core-mapping" href="role-map-button-pressed">`aria-pressed`</a> and
-                <a class="core-mapping" href="role-map-button-haspopup">`aria-haspopup`</a> attributes are declared.
+                <a class="core-mapping" href="role-map-button-haspopup">`aria-haspopup`</a> attributes are specified.
               </td>
             </tr>
             <tr tabindex="-1" id="el-canvas">
@@ -859,12 +860,31 @@
                 <a data-cite="HTML">`dd`</a>
               </th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-definition">`definition`</a> role
+                No corresponding role
               </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ia2">
+                ???
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                ???
+              </td>
+              <td class="atk">
+                ???
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXDescription`
+                </div>
+                <!-- <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span>
+                </div> -->
+              </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-del">
@@ -997,12 +1017,41 @@
                 <a data-cite="HTML">`dt`</a>
               </th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-term">`term`</a> role
+                No corresponding role
               </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_LISTITEM`
+                </div>
+                <div class="states">
+                  <span class="type">States:</span> `STATE_SYSTEM_READONLY`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `ListItem`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"details"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_LIST_ITEM`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                ???
+               <!--  <div class="subrole">
+                  <span class="type">AXSubrole:</span> ???
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> ???
+                </div> -->
+              </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-em">
@@ -1172,111 +1221,69 @@
             </tr>
             <tr tabindex="-1" id="el-footer">
               <th>
-                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element, or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="HTML">`body`</a>)
+                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element,  or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="HTML">`body`</a>)
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"footer"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_FOOTER`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-form">
-              <th>
-                <a data-cite="HTML">`form`</a> with an <a class="termref">accessible name</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-form ">`form`</a> role
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-form-no-accessible-name">
+            <tr tabindex="-1" id="el-form">
               <th>
-                <a data-cite="HTML">`form`</a> without an <a class="termref">accessible name</a>
+                <a data-cite="HTML">`form`</a>
               </th>
-              <td class="aria">No corresponding role</td>
+              <td class="aria">
+                <div>If provided an <a class="termref">accessible name</a> <a class="core-mapping" href="#role-map-form">`form`</a> role.</div>
+                <div>Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</div>
+              </td>
               <td class="ia2">
                 <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
+                <div class="relations">
+                  <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
                 </div>
               </td>
               <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
+                <div class="role">
+                  <span class="type">Role:</span> Use WAI-ARIA mapping
                 </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"form"`
+                <div class="general">
+                  Accessible name derived from `figcaption` according to the <a href="#figure-element-accessible-name-computation">`figure` Element Accessible Name Computation</a>
                 </div>
               </td>
               <td class="atk">
                 <div class="role">
-                  <span class="type">Role: </span> `ATK_ROLE_SECTION`
+                  <span class="type">Role:</span> Use WAI-ARIA mapping</div>
+                <div class="name">
+                  <span class="type">Name:</span> related <a href="#el-figcaption">`figcaption`</a> content
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces: </span> `AtkText`; `AtkHypertext`
+                <div class="relations">
+                  <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
                 </div>
               </td>
               <td class="ax">
                 <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
+                  <span class="type">AXRole:</span> Use WAI-ARIA mapping
                 </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
+                <div class="subrole"></div>
               </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-form-associated-custom-element">
               <th>
-                <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example">form-associated custom element</a>
+                <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
               </th>
-              <td class="aria">If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, no corresponding role.</td>
+              <td class="aria">If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise,  <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
+              <td class="comments">
+                <strong>Note:</strong> the <a data-cite="html/custom-elements.html#custom-elements-face-example">creating a form-associated custom element example</a> in the HTML specification.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-h1-h6">
               <th>
@@ -1320,43 +1327,11 @@
               <th>
                 <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`main`</a> element, a <a data-cite="html/dom.html#sectioning-content">sectioning content</a> element, or a <a data-cite="html/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="html">`body`</a>)
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"header"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_HEADER`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-hgroup">
@@ -2086,39 +2061,11 @@
               <th>
                 <a data-cite="HTML">`ins`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_CONTENT_INSERTION`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"ins"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CONTENT_INSERTION`
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `xml-roles:insertion`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXInsertStyleGroup`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-insertion">`insertion`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-kbd">
@@ -2253,23 +2200,10 @@
             </tr>
             <tr tabindex="-1" id="el-li">
               <th>
-                <a data-cite="html">`li`</a> <span class="el-context">(parent is an <a data-cite="html">`ol`</a> or <a data-cite="html">`ul`</a>)</span>
+                <a data-cite="html">`li`</a> <span class="el-context">(parent is an <a data-cite="html">`ol`</a>, <a data-cite="html">`ul`</a> or <a data-cite="html">`menu`</a>)</span>
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-listitem">`listitem`</a> role with <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `li` elements within the parent `ol` or `ul` and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the `li` elements position within the set.
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-li-parentmenu">
-              <th>
-                <a data-cite="html">`li`</a> <span class="el-context">(parent is a <a data-cite="html">`menu`</a>)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-listitem">`listitem`</a> role  with <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `li` elements within the parent `menu` and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the `li` elements position within the set.
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2326,7 +2260,7 @@
               </td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-mark">
+            <tr tabindex="-1" id="el-mark"> <!-- aria 1.3 role -->
               <th><a data-cite="HTML">`mark`</a></th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
@@ -2429,47 +2363,12 @@
             </tr>
             <tr tabindex="-1" id="el-meter">
               <th><a data-cite="HTML">`meter`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_LEVEL_BAR`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleValue`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `ProgressBar`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `meter`
-                </div>
-                <div class="ctrlpattern">
-                  <span class="type">Control Pattern:</span> `RangeValue`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_LEVEL_BAR`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkValue`
-                </div>
-                <div class="properties"><span class="type">Properties:</span> `AtkRange`</div>
-              </td>
-              <td class="ax">
-                  <div class="role">
-                      <span class="type">AXRole:</span> `AXLevelIndicator`
-                  </div>
-                  <div class="subrole">
-                      <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                      <span class="type">AXRoleDescription:</span> `"level indicator"`
-                  </div>
-              </td>
-              <td class="comments">See <a href="https://github.com/w3c/html-aam/issues/2">GitHub issue #2</a>.</td>
+              <td class="aria"><a class="core-mapping" href="#role-map-meter">`meter`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-nav">
               <th><a data-cite="HTML">`nav`</a></th>
@@ -2561,41 +2460,11 @@
             </tr>
             <tr tabindex="-1" id="el-p">
               <th><a data-cite="HTML">`p`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_PARAGRAPH`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span>
-                  <code>ATK_ROLE_PARAGRAPH</code>
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-paragraph">`paragraph`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-param">
@@ -2664,8 +2533,10 @@
                 <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-progress">
-                <th><a href="https://www.w3.org/TR/html/sec-forms.html#the-progress-element"><code>progress</code></a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-progressbar"><code>progressbar</code></a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax"><code>aria-valuemax</code></a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin"><code>aria-valuemin</code></a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow"><code>aria-valuenow</code></a> property set to the current value of the progress bar </td>
+                <th><a data-cite="HTML">`progress`</a></th>
+                <td class="aria">
+                  <a class="core-mapping" href="#role-map-progressbar">`progressbar`</a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a> property set to the current value of the progress bar
+                </td>
                 <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
                 <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -2677,13 +2548,14 @@
                 <td class="aria">No corresponding role</td>
                 <td class="ia2">
                   <div class="role">
-                    <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; <code>IA2_ROLE_TEXT_FRAME</code>
+                    <span class="type">Roles:</span>
+                    `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
                   </div>
                   <div class="children">
-                    <span class="type">Children:</span> `ROLE_SYSTEM_TEXT` wrapped by quote marks using <code>ROLE_SYSTEM_STATICTEXT</code>
+                    <span class="type">Children:</span> `ROLE_SYSTEM_TEXT` wrapped by quote marks using `ROLE_SYSTEM_STATICTEXT`
                   </div>
                   <div class="ifaces">
-                    <span class="type">Interfaces:</span> <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>
+                    <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
                   </div>
                 </td>
                 <td class="uia">
@@ -2794,13 +2666,13 @@
                 </td>
                 <td class="ax">
                   <div class="role">
-                    <span class="type">AXRole:</span> <code>AXGroup</code>
+                    <span class="type">AXRole:</span> `AXGroup`
                   </div>
                   <div class="subrole">
-                      <span class="type">AXSubrole:</span> <code>AXRubyText</code>
+                      <span class="type">AXSubrole:</span> `AXRubyText`
                   </div>
                   <div class="roledesc">
-                      <span class="type">AXRoleDescription:</span> <code>"group"</code>
+                      <span class="type">AXRoleDescription:</span> `"group"`
                   </div>
                 </td>
                 <td class="comments"></td>
@@ -2844,339 +2716,256 @@
               </tr>
             -->
             <tr tabindex="-1" id="el-ruby">
-                <th><a data-cite="HTML">`ruby`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; <code>IA2_ROLE_TEXT_FRAME</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                        <span class="type">Control Type:</span> `Text`
-                  </div>
-                  <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"ruby"</code></div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    `ATK_ROLE_STATIC`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> <code>AXGroup</code>
-                  </div>
-                  <div class="subrole">
-                      <span class="type">AXSubrole:</span> <code>AXRubyInline</code>
-                  </div>
-                  <div class="roledesc">
-                      <span class="type">AXRoleDescription:</span> <code>"group"</code>
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`ruby`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Text`
+                </div>
+                <div class="ctrltype">
+                  <span class="type">Localized Control Type:</span> `"ruby"`
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span>
+                  `ATK_ROLE_STATIC`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXRubyInline`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-s">
-                <th><a data-cite="HTML">`s`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">No accessible object.</div>
-                  <div class="properties">
-                        <span class="type">Text attributes:</span> <code>text-line-through-style:solid</code> on the text container
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">No accessible object. Exposed as
-                    "text-line-through-style:solid" text attribute on the text container.
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`s`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">No accessible object.</div>
+                <div class="properties">
+                  <span class="type">Text attributes:</span> `text-line-through-style:solid` on the text container
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">No accessible object. Exposed as
+                  "text-line-through-style:solid" text attribute on the text container.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-samp">
-                <th><a data-cite="HTML">`samp`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">
-                    No accessible object. Styles are mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles are mapped into
-                    text attributes on its text container.
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`samp`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">
+                  No accessible object. Styles are mapped into text attributes on its text container.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  No accessible object. Styles are mapped into
+                  text attributes on its text container.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-script">
-                <th><a href="https://www.w3.org/TR/html/semantics-scripting.html#the-script-element"><code>script</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="html/scripting.html#the-script-element">`script`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-section">
-                  <th><a data-cite="HTML">`section`</a></th>
-                  <td class="aria">
-                    <a class="core-mapping" href="#role-map-region"><code>region</code></a> role if the <a>`section`</a> element has an <a class="termref">accessible name</a>. Otherwise, no corresponding role.
-                  </td>
-                  <td class="ia2">
-                    <div class="general">If the <a>`section`</a> element has an <a class="termref">accessible name</a>, use WAI-ARIA mapping. Otherwise:</div>
-                    <div class="role">
-                      <span class="type">Roles:</span> <code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_SECTION</code>
-                    </div>
-                    <div class="ifaces">
-                      <span class="type">Interfaces:</span> <code>IAccessibleText2</code>; <code>IAccessibleHypertext2</code>;
-                    </div>
-                  </td>
-                  <td class="uia">
-                    <div class="general">If the <a>`section`</a> element has an <a class="termref">accessible name</a>:</div>
-                    <div class="ctrltype"><span class="type">Control Type:</span> <code>Group</code></div>
-                    <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"section"</code> (all lower-case)</div>
-                    <div class="ctrltype"><span class="type">Landmark Type:</span> <code>Custom</code></div>
-                    <div class="ctrltype"><span class="type">Localized Landmark Type:</span> <code>"region"</code> (all lower-case)</div>
-                    <div class="general">Otherwise:</div>
-                    <div class="ctrltype"><span class="type">Control Type:</span> <code>Group</code></div>
-                  </td>
-                  <td class="atk">
-                    <div class="general">If the <a>`section`</a> element has an <a class="termref">accessible name</a>, use WAI-ARIA mapping. Otherwise:</div>
-                    <div class="role">
-                      <span class="type">Role: </span>
-                      <code>ATK_ROLE_SECTION</code>
-                    </div>
-                     <div class="ifaces">
-                      <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                    </div>
-                  </td>
-                  <td class="ax">
-                    <div class="general">If the <a>`section`</a> element has an <a class="termref">accessible name</a>, use WAI-ARIA mapping. Otherwise:</div>
-                    <div class="role">
-                      <span class="type">AXRole:</span> <code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                      <span class="type">AXSubrole:</span> `(nil)`
-                    </div>
-                    <div class="roledesc">
-                      <span class="type">AXRoleDescription:</span> <code>"group"</code>
-                    </div>
-                  </td>
-                  <td class="comments"></td>
+              <th><a data-cite="HTML">`section`</a></th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an <a class="termref">accessible name</a>.
+                Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a>
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-select-listbox">
-                <th>
-                  <a href="https://www.w3.org/TR/html/sec-forms.html#the-select-element"><code>select</code></a>
-                  <span class="el-context">
-                    (with a <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-select-multiple"><code>multiple</code></a> attribute or
-                    <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-select-size"><code>size</code></a> attribute having value greater than <code>1</code>)
-                  </span>
-                </th>
-                <td class="aria"><a class="core-mapping" href="#role-map-listbox"><code>listbox</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`select`</a>
+                <span class="el-context">
+                  (with a <a data-cite="html/form-elements.html#attr-select-multiple">`multiple`</a> attribute or
+                  <a data-cite="html/form-elements.html#attr-select-size">`size`</a> attribute having value greater than `1`)
+                </span>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-listbox">`listbox`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-select-combobox">
-                <th>
-                  <a href="https://www.w3.org/TR/html/sec-forms.html#the-select-element"><code>select</code></a>
-                  <span class="el-context">
-                    (with NO <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-select-multiple"><code>multiple</code></a> attribute
-                    and NO <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-select-size"><code>size</code></a> attribute having value greater than <code>1</code>)
-                  </span>
-                </th>
-                <td class="aria"><a class="core-mapping" href="#role-map-combobox"><code>combobox</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`select`</a>
+                <span class="el-context">
+                  (with NO <a data-cite="html/form-elements.html#attr-select-multiple">`multiple`</a>  attribute
+                  and NO <a data-cite="html/form-elements.html#attr-select-size">`size`</a> attribute having value greater than `1`)
+                </span>
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-combobox">`combobox`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-slot">
-                <th><a data-cite="HTML">`slot`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`slot`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-small">
-                <th><a data-cite="HTML">`small`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">No accessible object.</div>
-                  <div class="properties">
-                    <span class="type">Text attributes:</span> <code>font-size</code> on the text container
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Exposed by <code>FontSize</code> attribute of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object. Exposed as "font-size"
-                    text attribute on the text container.
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`small`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">No accessible object.</div>
+                <div class="properties">
+                  <span class="type">Text attributes:</span> `font-size` on the text container
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">No accessible object. Exposed by `FontSize` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  No accessible object. Exposed as "font-size"
+                  text attribute on the text container.
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-source">
-                <th><a data-cite="HTML">`source`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`source`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-span">
-                <th><a data-cite="HTML">`span`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia">
-                    <div class="ctrltype">
-                        <span class="type">Control Type:</span> <code>Group</code>
-                    </div>
-                </td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`span`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia">
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Group`
+                </div>
+              </td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-strong">
-                <th><a data-cite="HTML">`strong`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">
-                    No accessible object. Styles used are mapped into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">
-                    No accessible object. Styles used are mapped
-                    into text attributes on its text container.
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`strong`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-strong">`strong`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-style">
-                <th><a data-cite="HTML">`style`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments">
-                  <div class="general">
-                    <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs. For instance, <code>display: none</code> or <code>visibility: hidden</code> will remove an element from the accessibility tree and hide its presence from assistive technologies.
-                  </div>
-                </td>
+              <th><a data-cite="HTML">`style`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments">
+                <div class="general">
+                  <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs. For instance, <code>display: none</code> or <code>visibility: hidden</code> will remove an element from the accessibility tree and hide its presence from assistive technologies.
+                </div>
+              </td>
             </tr>
             <tr tabindex="-1" id="el-sub">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sub</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles:</span> <code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_TEXT_FRAME</code>
-                  </div>
-                  <div class="properties">
-                    <span class="type">Text attributes:</span> <code>text-position:sub</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                      <span class="type">Control Type:</span> `Text`
-                  </div>
-                  <div class="general">Styles used are exposed by <code>IsSubscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    <code>ATK_ROLE_SUBSCRIPT</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole:</span> <code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole:</span> <code>AXSubscriptStyleGroup</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription:</span> <code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`sub`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-subscript">`subscript`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-summary">
               <th>
@@ -3225,54 +3014,28 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-sup">
-                <th><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-sub-and-sup-elements"><code>sup</code></a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Roles:</span> <code>ROLE_SYSTEM_GROUPING</code>; <code>IA2_ROLE_TEXT_FRAME</code>
-                  </div>
-                  <div class="properties">
-                    <span class="type">Text attributes:</span> <code>text-position:super</code>
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                      <span class="type">Control Type:</span> `Text`
-                  </div>
-                  <div class="general">Styles used are exposed by <code>IsSuperscript</code> attribute of the <code>TextRange</code> Control Pattern implemented on the accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    <code>ATK_ROLE_SUPERSCRIPT</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole:</span> <code>AXGroup</code>
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole:</span> <code>AXSuperscriptStyleGroup</code>
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription:</span> <code>"group"</code>
-                    </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`sup`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-superscript">`superscript`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-svg">
-                <th><a href="https://www.w3.org/TR/html/semantics-embedded-content.html#svg"><code>svg</code></a></th>
-                <td class="aria"><a class="graphics-mapping" href="https://www.w3.org/TR/graphics-aam-1.0/#role-map-graphics-document"><code>graphics-document</code> role</a></td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="html/embedded-content-other.html#svg-0">`svg`</a></th>
+              <td class="aria">
+                <a class="graphics-mapping" href="https://www.w3.org/TR/graphics-aam-1.0/#role-map-graphics-document">`graphics-document` role</a>
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-table">
               <th><a data-cite="HTML">`table`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-table"><code>table</code></a> role</td>
+              <td class="aria"><a class="core-mapping" href="#role-map-table">`table`</a> role</td>
               <td class="ia2">Use WAI-ARIA mapping</td>
               <td class="uia">Use WAI-ARIA mapping</td>
               <td class="atk">Use WAI-ARIA mapping</td>
@@ -3281,7 +3044,7 @@
             </tr>
             <tr tabindex="-1" id="el-tbody">
               <th><a data-cite="HTML">`tbody`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup"><code>rowgroup</code></a> role</td>
+              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
               <td class="ia2">Use WAI-ARIA mapping</td>
               <td class="uia">Use WAI-ARIA mapping</td>
               <td class="atk">Use WAI-ARIA mapping</td>
@@ -3289,49 +3052,53 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-td">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-td-element"><code>td</code></a> (ancestor <a href="https://www.w3.org/TR/html/tabular-data.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-table"><code>table</code></a> role)</th>
-                <td class="aria"><a class="core-mapping" href="#role-map-cell"><code>cell</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`td`</a> (ancestor <a data-cite="HTML">`table`</a> element has <a class="core-mapping" href="#role-map-table">`table`</a> role)</th>
+              <td class="aria"><a class="core-mapping" href="#role-map-cell">`cell`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-td-gridcell">
-                <th><a href="https://www.w3.org/TR/html/tabular-data.html#the-td-element"><code>td</code></a> (ancestor <a href="https://www.w3.org/TR/html/tabular-data.html#the-table-element"><code>table</code></a> element has <a class="core-mapping" href="#role-map-grid"><code>grid</code></a> or <a class="core-mapping" href="#role-map-treegrid"><code>treegrid</code></a> role)</th>
-                <td class="aria"><a class="core-mapping" href="#role-map-gridcell"><code>gridcell</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th>
+                <a data-cite="HTML">`td`</a> (ancestor <a data-cite="HTML">`table`</a> element has <a class="core-mapping" href="#role-map-grid">`grid`</a> or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
+              </th>
+              <td class="aria"><a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-template">
-                <th><a data-cite="HTML">`template`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`template`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-textarea">
-                <th><a data-cite="HTML">`textarea`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role, with the <a class="core-mapping" href="#ariaMultilineTrue"><code>aria-multiline</code></a> property set to "true"</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`textarea`</a></th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role, with the <a class="core-mapping" href="#ariaMultilineTrue">`aria-multiline`</a> property set to "true"
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-tfoot">
-                <th><a data-cite="HTML">`tfoot`</a></th>
-                <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`tfoot`</a></th>
+              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-th">
               <th>
@@ -3340,7 +3107,8 @@
                   <a data-cite="HTML/tables.html#column-header">column header</a>
                   nor <a data-cite="HTML/tables.html#row-header">row header</a>,
                   and ancestor <a data-cite="HTML">`table`</a> element has
-                  <a class="core-mapping" href="#role-map-table">`table`</a> role)</span>
+                  <a class="core-mapping" href="#role-map-table">`table`</a> role)
+                </span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-cell">`cell`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3351,13 +3119,14 @@
             </tr>
             <tr tabindex="-1" id="el-th-gridcell">
               <th>
-                <a href="https://www.w3.org/TR/html/tabular-data.html#the-th-element">`th`</a>
+                <a data-cite="HTML">`th`</a>
                 <span class="el-context">(is neither
                   <a data-cite="HTML/tables.html#column-header">column header</a>
                   nor <a data-cite="HTML/tables.html#row-header">row header</a>,
                   and ancestor <a data-cite="HTML">`table`</a> element has
                   <a class="core-mapping" href="#role-map-grid">`grid`</a>
-                  or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)</span>
+                  or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
+                </span>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3405,57 +3174,21 @@
             </tr>
             <tr tabindex="-1" id="el-time">
               <th><a data-cite="HTML">`time`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_TEXT_FRAME`
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `xml-roles:time`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"time"`
-                </div>
-                 <div class="general">Note: create a separate UIA Control of type Text. This is different from most UIA text mappings, which only create ranges in the page text pattern.</div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  <p class="role"><span class="type">Role: </span> `ATK_ROLE_STATIC`</p>
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `xml-roles:time`
-                </div>
-                <div class="ifaces"> <span class="type">Interfaces: </span> `AtkText`; `AtkHypertext`</div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXTimeGroup`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-time">`time`</a></td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-title">
-                <th><a data-cite="HTML">`title`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2"><div class="general">Not mapped</div></td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk"><div class="general">Not mapped</div></td>
-                <td class="ax"><div class="general">Not mapped</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`title`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-tr">
               <th><a data-cite="HTML">`tr`</a></th>
@@ -3476,92 +3209,91 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-u">
-                <th><a data-cite="HTML">`u`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">No accessible object. Exposed as "text-underline-style:solid" text attribute on its text container.
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Exposed by <code>UnderlineStyle</code> attribute of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">No accessible object. Exposed as
-                    "text-underline-style:solid" text attribute on its text container.
-                  </div>
-                </td>
-                <td class="ax">Not mapped</td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`u`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">No accessible object. Exposed as "text-underline-style:solid" text attribute on its text container.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">No accessible object. Exposed by `UnderlineStyle` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">No accessible object. Exposed as
+                  "text-underline-style:solid" text attribute on its text container.
+                </div>
+              </td>
+              <td class="ax">Not mapped</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-ul">
-                <th><a data-cite="HTML">`ul`</th>
-                <td class="aria"><a class="core-mapping" href="#role-map-list"><code>list</code></a> role</td>
-                <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`ul`</th>
+              <td class="aria"><a class="core-mapping" href="#role-map-list"><code>list</code></a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-var">
-                <th><a data-cite="HTML">`var`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
-                </td>
-                <td class="uia">
-                  <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="comments"></td>
+              <th><a data-cite="HTML">`var`</a></th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
+              </td>
+              <td class="uia">
+                <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the <code>TextRange</code> Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"group"`
+                </div>
+              </td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-video">
               <th><a data-cite="HTML">`video`</a></th>
               <td class="aria">No corresponding role</td>
               <td class="ia2">
                 <div class="role">
-                  <span class="type">Role:</span> <code>ROLE_SYSTEM_GROUPING</code>
+                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
                 </div>
               </td>
               <td class="uia">
-                  <div class="ctrltype">
-                      <span class="type">Control Type:</span> <code>Group</code>
-                  </div>
-                  <div class="ctrltype"><span class="type">Localized Control Type:</span> <code>"group"</code></div>
-                  <div class="general"><b>Note:</b> If the <a href="https://www.w3.org/TR/html/semantics.html#attr-media-controls"><code>controls</code></a> attribute is present, UI controls (e.g. play, volume) are exposed as children of the <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-video-element"><code>video</code></a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g. <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider"><code>slider</code></a>).</div>
-                  <div class="general">Text objects associated with loading or error messages, and any UI control not currently displayed, MAY be present in the <a class="termref">accessibility tree</a> and marked as hidden or off-screen.</div>
+                <div class="ctrltype">
+                  <span class="type">Control Type:</span> `Group`
+                </div>
+                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"group"`</div>
+                <div class="general"><b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g. play, volume) are exposed as children of the <a data-cite="HTML">`video`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g. <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).</div>
+                <div class="general">Text objects associated with loading or error messages, and any UI control not currently displayed, MAY be present in the <a class="termref">accessibility tree</a> and marked as hidden or off-screen.</div>
               </td>
               <td class="atk">
                 <div class="role">
-                  <span class="type">Role: </span>
-                  <code>ATK_ROLE_VIDEO</code>
+                  <span class="type">Role:</span> `ATK_ROLE_VIDEO`
                 </div>
               </td>
               <td class="ax">
-                  <div class="role">
-                      <span class="type">AXRole:</span> <code>AXGroup</code>
-                  </div>
-                  <div class="subrole">
-                      <span class="type">AXSubrole:</span> <code>AXVideo</code>
-                  </div>
-                  <div class="roledesc">
-                      <span class="type">AXRoleDescription:</span> <code>"video playback"</code>
-                  </div>
-                  <div class="general"><b>Note:</b> If the <a href="https://www.w3.org/TR/html/semantics.html#attr-media-controls"><code>controls</code></a> attribute is present, UI controls (e.g. play, volume) are exposed as descendants of an <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar"><code>toolbar</code></a>, and mapped as appropriate for the type of control (e.g. <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider"><code>slider</code></a>).</div>
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXGroup`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `AXVideo`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"video playback"`
+                </div>
+                  <div class="general"><b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g. play, volume) are exposed as descendants of an <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g. <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).</div>
               </td>
               <td class="comments"></td>
             </tr>


### PR DESCRIPTION
largely related to #229, but does not completely close.
closes #302
closes #249 and closes #251  - ref core aam for mapping of `figcaption` now

see commit messages for more info


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/326.html" title="Last updated on Apr 24, 2021, 10:00 PM UTC (ad95af6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/326/bbf646a...ad95af6.html" title="Last updated on Apr 24, 2021, 10:00 PM UTC (ad95af6)">Diff</a>