### PR TITLE
dialog open attribute mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -1067,7 +1067,9 @@
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
+              <td class="comments">
+                See also the `dialog` element's <a href="#att-open-dialog">`open`</a> attribute.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-div">
               <th>
@@ -5279,17 +5281,24 @@
               <td class="elements"><a data-cite="html/interactive-elements.html#attr-dialog-open">`dialog`</a></td>
               <td class="aria">
                 <div class="general">
-                  If the `open` attribute is set via the `showModal()` method then the `dialog` will be set to `display: block`, <a class="core-mapping" href="#ariaModalTrue">`aria-modal="true"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+                  If the `open` attribute is set via the `showModal()` method then <a class="core-mapping" href="#ariaModalTrue">`aria-modal="true"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
                 </div>
                 <div class="general">
-                  Otherwise, if the `open` attribute is set via the `show()` method, or explicitly specified by an author, then the `dialog` will be set to `display: block`, <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+                  Otherwise, if the `open` attribute is set via the `show()` method, or explicitly specified by an author, then <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
                 </div>
               </td>
               <td class="ia2">Use WAI-ARIA mapping</td>
               <td class="uia">Use WAI-ARIA mapping</td>
               <td class="atk">Use WAI-ARIA mapping</td>
               <td class="ax">Use WAI-ARIA mapping</td>
-              <td class="comments"></td>
+              <td class="comments">
+                <p>
+                  The `open` attribute's value is irrelevant. When the `open` attribute is not specified the default user agent styling for a `dialog` is `display: none`.
+                </p>
+                <p>
+                  Authors can reveal a `dialog` through the style layer by modifying its `display` property. If revealed this way then the `dialog` is <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+                </p>
+              </td>
             </tr>
             <tr tabindex="-1" id="att-optimum">
               <th>`optimum`</th>

--- a/index.html
+++ b/index.html
@@ -5276,20 +5276,19 @@
             </tr>
             <tr tabindex="-1" id="att-open-dialog">
               <th>`open`</th>
-              <td class="elements"><a href="https://w3c.github.io/html/interactive-elements.html#element-attrdef-dialog-open">`dialog`</a></td>
-              <td class="aria"><a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded`</a>="true | false"</td>
-              <td class="ia2">`STATE_SYSTEM_EXPANDED`<br />`STATE_SYSTEM_COLLAPSED`</td>
-              <td class="uia">
-                <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.expandcollapsepattern.aspx">`ExpandCollapsePattern`</a>
-              </td>
-              <td class="atk">
-                <div class="states">
-                  <span class="type">States: </span>
-                  `ATK_STATE_COLLAPSED` or `ATK_STATE_EXPANDED` depending
-                  on the attribute value
+              <td class="elements"><a data-cite="html/interactive-elements.html#attr-dialog-open">`dialog`</a></td>
+              <td class="aria">
+                <div class="general">
+                  If the `open` attribute is set via the `showModal()` method then the `dialog` will be set to `display: block`, <a class="core-mapping" href="#ariaModalTrue">`aria-modal="true"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+                </div>
+                <div class="general">
+                  Otherwise, if the `open` attribute is set via the `show()` method, or explicitly specified by an author, then the `dialog` will be set to `display: block`, <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
                 </div>
               </td>
-              <td class="ax">`AXExpanded: YES|NO`</td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-optimum">


### PR DESCRIPTION
Closes #265

@joanmarie finally took a stab at revising the incorrect `open` mappings for the `dialog` element.  Not sure if the `aria-modal` references need to be in there. But wanted to call out that `open` can represent a non-modal or modal dialog depending on the method that it is specified on the element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/329.html" title="Last updated on Apr 26, 2021, 12:56 PM UTC (e638b14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/329/08ac91c...e638b14.html" title="Last updated on Apr 26, 2021, 12:56 PM UTC (e638b14)">Diff</a>