### PR TITLE
Update auto-publish to ARIA WG decision

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           TOOLCHAIN: respec
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          W3C_WG_DECISION_URL: "https://github.com/w3c/html-aam/pull/68"
+          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-aria-admin/2021Aug/0001.html"
           W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"
           W3C_BUILD_OVERRIDE: |
             specStatus: WD


### PR DESCRIPTION
Since the spec has moved to ARIA, the auto-publish config should use the ARIA WG decision to publish.