### PR TITLE
aside mapping revisions

### DIFF
--- a/index.html
+++ b/index.html
@@ -433,7 +433,9 @@
             </tr>
             <tr tabindex="-1" id="el-aside">
               <th>
-                <a data-cite="HTML">`aside`</a> (scoped to a sectioning content element, or a sectioning root element other than `body`)
+                <a data-cite="HTML">`aside`</a> 
+                (scoped to a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element, 
+                or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than `body`)
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role if the <a>`aside`</a> element has an <a>accessible name</a>. 

--- a/index.html
+++ b/index.html
@@ -458,18 +458,29 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-aside">
+            <tr tabindex="-1" id="el-aside-ancestorbodymain">
               <th>
-                <a data-cite="HTML">`aside`</a>
+                <a data-cite="HTML">`aside`</a> (scoped to the `body` or `main` element)
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"aside"`</div>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="el-aside">
+              <th>
+                <a data-cite="HTML">`aside`</a> (scoped to a sectioning content element, or a sectioning root element other than `body`)
+              </th>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role if the <a>`aside`</a> element has an <a>accessible name</a>. 
+                Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
               </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>


### PR DESCRIPTION
closes #86

Treat an `aside` element similarly to `header`, `footer` and `section`.

map `aside` to `role=complementary` if:
* scoped to `main` or `body` elements
* or given accessible name if scoped to sectioning content or root elements

otherwise, map to `role=generic`


<!--
Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
-->


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/350.html" title="Last updated on Nov 7, 2021, 6:41 PM UTC (ab6b093)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/350/538a078...ab6b093.html" title="Last updated on Nov 7, 2021, 6:41 PM UTC (ab6b093)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/350.html" title="Last updated on Apr 3, 2022, 4:30 PM UTC (e429a37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/350/13721fb...e429a37.html" title="Last updated on Apr 3, 2022, 4:30 PM UTC (e429a37)">Diff</a>