### PR TITLE
remove platform specifics for section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2950,62 +2950,13 @@
             <tr tabindex="-1" id="el-section">
               <th><a data-cite="HTML">`section`</a></th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an <a class="termref">accessible name</a>. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
+                <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an 
+                <a class="termref">accessible name</a>. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
               </td>
-              <td class="ia2">
-                <div class="general">
-                  If the <a>`section`</a> element has an <a class="termref">accessible name</a>, use WAI-ARIA mapping. Otherwise:
-                </div>
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  If the <a>`section`</a> element has an <a class="termref">accessible name</a>:
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"section"` (all lower-case)
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Landmark Type:</span> `Custom`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Landmark Type:</span> `"region"` (all lower-case)
-                </div>
-                <div class="general">Otherwise:</div>
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">If the <a>`section`</a> element has an <a class="termref">accessible name</a>, use WAI-ARIA mapping. Otherwise:</div>
-                <div class="role">
-                  <span class="type">Role: </span>
-                  `ATK_ROLE_SECTION`
-                </div>
-                 <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">If the <a>`section`</a> element has an <a class="termref">accessible name</a>, use WAI-ARIA mapping. Otherwise:</div>
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-select-listbox">


### PR DESCRIPTION
closes #361

updates `section` mappings to just point to core aam


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/362.html" title="Last updated on Jan 21, 2022, 1:33 PM UTC (7988404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/362/6da7e1d...7988404.html" title="Last updated on Jan 21, 2022, 1:33 PM UTC (7988404)">Diff</a>