### PR TITLE
update HTML element mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -647,7 +647,7 @@
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments">
                 A `button`'s mapping will change if the
-                <a class="core-mapping" href="#role-map-button-pressed">`aria-pressed`</a> and
+                <a class="core-mapping" href="#role-map-button-pressed">`aria-pressed`</a> or
                 <a class="core-mapping" href="#role-map-button-haspopup">`aria-haspopup`</a> attributes are specified.
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -286,43 +286,12 @@
                 <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
               </th>
               <td class="aria">
-                No corresponding role
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleHyperlink`; `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span>
-                  `ATK_ROLE_STATIC`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</a></div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-abbr">
@@ -338,10 +307,6 @@
                   <span class="type">Object attributes:</span>
                   "abbr" attribute on the containing <a href="#el-td">`td`</a> if a single child, text content used as a value
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -355,9 +320,6 @@
                 <div class="objattrs">
                   <span class="type">Object attributes:</span>
                   "abbr" attribute on the containing <a href="#el-td">`td`</a> if a single child, text content used as a value
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
@@ -381,10 +343,6 @@
                   <span class="type">Roles:</span>
                   `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -394,9 +352,6 @@
               <td class="atk">
                 <div class="role">
                   <span class="type">Role:</span> `ATK_ROLE_SECTION`
-                </div>
-                 <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
@@ -1081,9 +1036,6 @@
                 <div class="relations">
                   <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -1097,9 +1049,6 @@
                 <div class="relations">
                   <span class="type">Relations:</span>
                   `ATK_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
@@ -1162,66 +1111,25 @@
               <td class="aria">
                 <a class="core-mapping" href="#role-map-contentinfo">`contentinfo`</a> role
               </td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"footer"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="ax">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"footer"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-footer">
               <th>
-                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element, or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="HTML">`body`</a>)
+                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element, 
+                a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element, 
+                or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="HTML">`body`</a>)
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"footer"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_FOOTER`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-form">
@@ -1241,14 +1149,11 @@
               <th>
                 <a data-cite="HTML">`form`</a> without an <a class="termref">accessible name</a>
               </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"form"`
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
@@ -1294,10 +1199,7 @@
                 <a class="core-mapping" href="#role-map-banner">`banner`</a> role
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="properties"><span class="type">Localized Control Type:</span> `"header"`</div>
-              </td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
@@ -1306,43 +1208,13 @@
               <th>
                 <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`main`</a> element, a <a data-cite="html/dom.html#sectioning-content">sectioning content</a> element, or a <a data-cite="html/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="html">`body`</a>)
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`;
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"header"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_HEADER`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-hgroup">
@@ -2205,9 +2077,6 @@
                 <div class="relations">
                   <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with a form control that is child to the `label` or referred to by the `label` element's <a href="#att-for-label">`for`</a> attribute. The associated form element has `IA2_RELATION_LABELLED_BY` pointing to the `label`.
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -2226,9 +2095,6 @@
                 <div class="relations">
                   <span class="type">Relations: </span>
                   `ATK_RELATION_LABEL_FOR` for a child form element or form element referred by <a href="#att-for-label">`for`</a> attribute. Note, related form element provides `ATK_RELATION_LABELLED_BY` pointing to the label.
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
@@ -2254,10 +2120,6 @@
                 <div class="relations">
                   <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with the parent <a href="#el-fieldset">`fieldset`</a>
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -2276,9 +2138,6 @@
                 <div class="relations">
                   <span class="type">Relations:</span>
                   `ATK_RELATION_LABEL_FOR` with parent <a href="#el-fieldset">`fieldset`</a> element
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
                 </div>
              </td>
               <td class="ax">
@@ -2388,11 +2247,6 @@
                     Styles used are mapped to text attributes on the accessible object.
                   </span>
                 </p>
-                <p>
-                  <span class="ifaces">
-                    <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                  </span>
-                </p>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -2417,9 +2271,6 @@
                 <p>
                   <span class="general">Styles used are mapped to text attributes on the accessible object.</span>
                 </p>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
               </td>
               <td class="ax">
                 <div class="role">
@@ -2613,10 +2464,6 @@
                 <div class="general">
                   Styles used are mapped to text attributes on the parent accessible object.
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleText2`; `IAccessibleHypertext2`
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -2633,10 +2480,6 @@
                 </div>
                 <div class="general">
                   Styles used are mapped to text attributes on the accessible object.
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
@@ -2675,9 +2518,6 @@
                 <div class="children">
                   <span class="type">Children:</span> `ROLE_SYSTEM_TEXT` wrapped by quote marks using `ROLE_SYSTEM_STATICTEXT`
                 </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`
-                </div>
               </td>
               <td class="uia">
                 <div class="ctrltype">
@@ -2691,10 +2531,6 @@
                 <div class="role">
                   <span class="type">Role:</span>
                   `ATK_ROLE_STATIC`
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span>
-                  `AtkText`; `AtkHypertext`
                 </div>
               </td>
               <td class="ax">
@@ -2907,33 +2743,11 @@
             </tr>
             <tr tabindex="-1" id="el-samp">
               <th><a data-cite="HTML">`samp`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. Styles are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Styles are mapped into
-                  text attributes on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-script">
@@ -3041,25 +2855,13 @@
             </tr>
             <tr tabindex="-1" id="el-span">
               <th><a data-cite="HTML">`span`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-strong">
@@ -3072,6 +2874,7 @@
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
+            </tr>
             <tr tabindex="-1" id="el-style">
               <th><a data-cite="HTML">`style`</a></th>
               <td class="aria">No corresponding role</td>
@@ -3081,7 +2884,9 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments">
                 <div class="general">
-                  <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs. For instance, `display: none` or `visibility: hidden` will remove an element from the accessibility tree and hide its presence from assistive technologies.
+                  <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs. 
+                  For instance, `display: none` or `visibility: hidden` will remove an element from the accessibility tree 
+                  and hide its presence from assistive technologies.
                 </div>
               </td>
             </tr>
@@ -3163,7 +2968,8 @@
               <td class="atk">See comments</td>
               <td class="ax">See comments</td>
               <td class="comments">
-                Mapping for `svg` is defined by [[[svg-aam-1.0]]]. See also <a href="https://w3c.github.io/graphics-aam/#mapping_role_table">Graphics Accessibility API Role Mappings</a>
+                Mapping for `svg` is defined by [[[svg-aam-1.0]]]. 
+                See also <a href="https://w3c.github.io/graphics-aam/#mapping_role_table">Graphics Accessibility API Role Mappings</a>
               </td>
             </tr>
             <tr tabindex="-1" id="el-table">
@@ -3223,7 +3029,8 @@
             <tr tabindex="-1" id="el-textarea">
               <th><a data-cite="HTML">`textarea`</a></th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role, with the <a class="core-mapping" href="#ariaMultilineTrue">`aria-multiline`</a> property set to "true"
+                <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role, 
+                with the <a class="core-mapping" href="#ariaMultilineTrue">`aria-multiline`</a> property set to "true"
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
@@ -3307,11 +3114,7 @@
               <th><a data-cite="HTML">`thead`</a></th>
               <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Header`
-                </div>
-              </td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
@@ -3334,13 +3137,13 @@
               <td class="uia"><div class="general">Not mapped</div></td>
               <td class="atk"><div class="general">Not mapped</div></td>
               <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
+              <td class="comments">A `title` element provides the <a class="termref">accessible name</a> for its document.</td>
             </tr>
             <tr tabindex="-1" id="el-tr">
               <th><a data-cite="HTML">`tr`</a></th>
               <td class="aria"><a class="core-mapping" href="#role-map-row">`row`</a> role</td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Generally not mapped. If the element must be included per Core-AAM Section 5.1.2, map as `Group`.</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>

--- a/index.html
+++ b/index.html
@@ -6312,7 +6312,8 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
-          <li>66-Feb-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>
+          <li>06-Mar-2022: Update the following elements to map to the `generic` role: `a no href`, `footer` not scoped to `body`, `header` not scoped to `body`, `samp`, `span`. See <a href="https://github.com/w3c/html-aam/pull/364">GitHub PR 364</a>.</li>
+          <li>06-Feb-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>
           <li>02-Nov-2021: Updating `blockquote`, `caption`, `code`, `del`, `em`, `ins`, `meter`, `paragraph`, `strong`, `sub`, `sup` and `time` to ARIA 1.2 mappings in Core AAM.  Fix `body` mapping to `generic`, and `html` mapping to `document`. Fix `hgroup` mapping to `generic`.  Update `details` to map to `group` with additional information specific to ATK, UIA. See <a href="https://github.com/w3c/html-aam/pull/348">GitHub issue #348</a></li>
           <li>12-May-2021: Add FACES references to attributes table - `readonly`, `name`, `form`, `disabled`. See <a href="https://github.com/w3c/html-aam/issues/257">Issue 257</a>.</li>
           <li>12-Dec-2019: Adds `hgroup`, `slot`, autonomous custom element and form associated custom element. See <a href="https://github.com/w3c/html-aam/issues/189">GitHub issue #189</a>.</li>


### PR DESCRIPTION
closes #363 by removing unnecessary instances of specifying 'interfaces' for ia2/atk

starts to resolve more `generic` mappings, per #346.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/364.html" title="Last updated on Mar 7, 2022, 12:18 AM UTC (cca9b99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/364/5d42f43...cca9b99.html" title="Last updated on Mar 7, 2022, 12:18 AM UTC (cca9b99)">Diff</a>