### PR TITLE
update mark mapping to core aam

### DIFF
--- a/index.html
+++ b/index.html
@@ -6501,6 +6501,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
+          <li>26-Jan-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>
           <li>02-Nov-2021: Updating `blockquote`, `caption`, `code`, `del`, `em`, `ins`, `meter`, `paragraph`, `strong`, `sub`, `sup` and `time` to ARIA 1.2 mappings in Core AAM.  Fix `body` mapping to `generic`, and `html` mapping to `document`. Fix `hgroup` mapping to `generic`.  Update `details` to map to `group` with additional information specific to ATK, UIA. See <a href="https://github.com/w3c/html-aam/pull/348">GitHub issue #348</a></li>
           <li>12-May-2021: Add FACES references to attributes table - `readonly`, `name`, `form`, `disabled`. See <a href="https://github.com/w3c/html-aam/issues/257">Issue 257</a>.</li>
           <li>12-Dec-2019: Adds `hgroup`, `slot`, autonomous custom element and form associated custom element. See <a href="https://github.com/w3c/html-aam/issues/189">GitHub issue #189</a>.</li>

--- a/index.html
+++ b/index.html
@@ -6501,7 +6501,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
-          <li>26-Jan-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>
+          <li>66-Feb-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>
           <li>02-Nov-2021: Updating `blockquote`, `caption`, `code`, `del`, `em`, `ins`, `meter`, `paragraph`, `strong`, `sub`, `sup` and `time` to ARIA 1.2 mappings in Core AAM.  Fix `body` mapping to `generic`, and `html` mapping to `document`. Fix `hgroup` mapping to `generic`.  Update `details` to map to `group` with additional information specific to ATK, UIA. See <a href="https://github.com/w3c/html-aam/pull/348">GitHub issue #348</a></li>
           <li>12-May-2021: Add FACES references to attributes table - `readonly`, `name`, `form`, `disabled`. See <a href="https://github.com/w3c/html-aam/issues/257">Issue 257</a>.</li>
           <li>12-Dec-2019: Adds `hgroup`, `slot`, autonomous custom element and form associated custom element. See <a href="https://github.com/w3c/html-aam/issues/189">GitHub issue #189</a>.</li>

--- a/index.html
+++ b/index.html
@@ -2369,69 +2369,13 @@
               </td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-mark"> <!-- aria 1.3 role -->
+            <tr tabindex="-1" id="el-mark"> 
               <th><a data-cite="HTML">`mark`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  <span class="role">
-                    <span class="type">Role:</span> `IA2_ROLE_TEXT_FRAME`
-                  </span>
-                </div>
-                <p>
-                  <span class="objattrs">
-                    <span class="type">Object attributes:</span>
-                  </span> `xml-roles:mark`
-                </p>
-                <p>
-                  <span class="general">
-                    Styles used are mapped to text attributes on the accessible object.
-                  </span>
-                </p>
-                <p>
-                  <span class="ifaces">
-                    <span class="type">Interfaces:</span> `IAccessibleText2`; `IAccessibleHypertext2`;
-                  </span>
-                </p>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"highlight"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  <p class="role">
-                    <span class="type">Role: </span> `ATK_ROLE_STATIC`
-                  </p>
-                </div>
-                <p>
-                  <span class="objattrs">
-                    <span class="type">Object attributes:</span>
-                    `xml-roles:mark`
-                  </span>
-                </p>
-                <p>
-                  <span class="general">Styles used are mapped to text attributes on the accessible object.</span>
-                </p>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `AtkText`; `AtkHypertext`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"highlight"`
-                </div>
-              </td>
+              <td class="aria"><a class="core-mapping" href="#role-map-mark">`mark`</a> role</td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-math">


### PR DESCRIPTION
core aam has the `mark` role defined.  So HTML AAM can point to that instead of having it here.

closes #316


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/365.html" title="Last updated on Feb 6, 2022, 11:04 PM UTC (c5466c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/365/33e2465...c5466c4.html" title="Last updated on Feb 6, 2022, 11:04 PM UTC (c5466c4)">Diff</a>