### PR TITLE
updated api refs for hgroup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1246,10 +1246,10 @@
                 <a data-cite="HTML">`hgroup`</a>
               </th>
               <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role </td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-hr">


### PR DESCRIPTION
changed from not mapped to use WAI-ARIA mapping as `hgroup` is mapped to `generic` role


The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:
using https://thepaciellogroup.github.io/AT-browser-tests/test-files/hgroup.html  looks like
supported by Chrome (exposed as `IA2_ROLE_SECTION` in line with IA2 mapping for `generic`
in Firefox exposed as `role:"text container"`, webkit needs checking
 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium 
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/374.html" title="Last updated on Mar 7, 2022, 10:41 PM UTC (2bcd3ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/374/367e04a...2bcd3ad.html" title="Last updated on Mar 7, 2022, 10:41 PM UTC (2bcd3ad)">Diff</a>