### PR TITLE
Remove jQuery, only needed for IE

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,9 +84,6 @@
       a11y: false
     };
   </script>
-  <!-- local resources - see line 18 -->
-  <script src="script/jquery.details.min.js"></script>
-  <!-- end local resources -->
   <script>
     var mappingTableLabels = {
       viewByTable: "View as a single table",


### PR DESCRIPTION
I missed one of the jQuery includes! we can also close this PR after this one is merged: https://github.com/w3c/html-aam/pull/371/files


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 24, 2022, 6:04 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fhtml-aam%2Fdcc5364265e3980a2a18a60ee4c21df0a07e3d3d%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aam%23407.)._
</details>
