### PR TITLE
Addition: inert attribute mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -4292,8 +4292,8 @@
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
                 <p>An inert element or the elements of an inert element's subtree cannot receive keyboard focus, nor will they respond to pointer events.</p>
-                <p>A `dialog` element can escape inertness of its inert ancestor when the `dialog` is modal and rendered in the browser's 
-                  <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a>.</p>
+                <p>A `dialog` element can escape an inert subtree when the `dialog` is in the modal state, and rendered in the browser's 
+                  <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a>.  A modal dialog, or its <a>flat tree</a> descendants can also become <a>inert</a>.  See <a data-cite="interaction.html#modal-dialogs-and-inert-subtrees">Modal dialogs and inert subtrees</a></p>
               </td>
             </tr>
             <tr tabindex="-1" id="att-indeterminate">

--- a/index.html
+++ b/index.html
@@ -4251,18 +4251,19 @@
               <td class="elements">
                 <a data-cite="html/interaction.html#the-inert-attribute">HTML elements</a>
               </td>
-              <td class="aria"><a class="core-mapping" href="#ariaHiddenTrue">`aria-hidden="true"`</a></td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="aria">Not Mapped</td>
+              <td class="ia2">See comments</td>
+              <td class="uia">See comments</td>
+              <td class="atk">See comments</td>
+              <td class="ax">See comments</td>
               <td class="comments">
-                <p>An inert element, nor the nodes if its subtree can receive keyboard focus, respond to pointer events, 
-                   or be otherwise reachable by assistive technology.
+                <p>
+                  Nodes that are inert are not exposed to an accessibility API.
                 </p>
-                <p>A `dialog` element can escape an inert subtree when the `dialog` is in the modal state, and rendered in the browser's 
-                  <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a> by use of the `showModal()` method. 
-                  See also <a data-cite="html/interaction.html#modal-dialogs-and-inert-subtrees">Modal dialogs and inert subtrees</a>.
+                <p class="note">
+                  Note: an inert node can have descendants that are not inert. For example, a
+                  <a data-cite="html/interaction.html#modal-dialogs-and-inert-subtrees">modal dialog</a>
+                  can escape an inert subtree.
                 </p>
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -4258,7 +4258,7 @@
               <td class="ax">See comments</td>
               <td class="comments">
                 <p>
-                  Nodes that are inert are not exposed to an accessibility API.
+                  Nodes that are <a data-cite="html/interaction.html#inert">inert</a> are not exposed to an accessibility API.
                 </p>
                 <p class="note">
                   Note: an inert node can have descendants that are not inert. For example, a

--- a/index.html
+++ b/index.html
@@ -6189,6 +6189,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
+          <li>23-Mar-2023: Add `inert` attribute mapping. See <a href="https://github.com/w3c/html-aam/pull/410">GitHub PR 410</a>.</li>
           <li>08-Mar-2023: Update `hgroup` element to be mapped to `role=group`. See  <a href="https://github.com/w3c/html-aam/pull/398">GitHub PR 398</a>.</li>
           <li>08-Mar-2023: Clarify naming algorithm for `output` element. See <a href="https://github.com/w3c/html-aam/pull/402">GitHub PR 402</a>.</li>
           <li>12-Dec-2022: Revise mapping for `s` element to be `role=deletion`. See <a href="https://github.com/w3c/html-aam/pull/442">GitHub PR 442</a>.</li>

--- a/index.html
+++ b/index.html
@@ -4280,6 +4280,22 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
+            <tr tabindex="-1" id="att-inert">
+              <th>`inert`</th>
+              <td class="elements">
+                <a data-cite="html/interaction.html#the-inert-attribute">HTML elements</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaHiddenTrue">`aria-hidden="true"`</a></td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments">
+                <p>An inert element or the elements of an inert element's subtree cannot receive keyboard focus, nor will they respond to pointer events.</p>
+                <p>A `dialog` element can escape inertness of its inert ancestor when the `dialog` is modal and rendered in the browser's 
+                  <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a>.</p>
+              </td>
+            </tr>
             <tr tabindex="-1" id="att-indeterminate">
               <th>`indeterminate [IDL]`</th>
               <td class="elements">

--- a/index.html
+++ b/index.html
@@ -4291,9 +4291,13 @@
               <td class="atk">Use WAI-ARIA mapping</td>
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
-                <p>An inert element or the elements of an inert element's subtree cannot receive keyboard focus, nor will they respond to pointer events.</p>
+                <p>An inert element, nor the nodes if its subtree can receive keyboard focus, respond to pointer events, 
+                   or be otherwise reachable by assistive technology.
+                </p>
                 <p>A `dialog` element can escape an inert subtree when the `dialog` is in the modal state, and rendered in the browser's 
-                  <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a>.  A modal dialog, or its <a>flat tree</a> descendants can also become <a>inert</a>.  See <a data-cite="interaction.html#modal-dialogs-and-inert-subtrees">Modal dialogs and inert subtrees</a></p>
+                  <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a> by use of the `showModal()` method. 
+                  See also <a data-cite="html/interaction.html#modal-dialogs-and-inert-subtrees">Modal dialogs and inert subtrees</a>.
+                </p>
               </td>
             </tr>
             <tr tabindex="-1" id="att-indeterminate">


### PR DESCRIPTION
closes #295

add `inert` attribute and mappings.

wondering if these need to call out that subtree elements should not be focusable re: their mappings, or if the comment here is sufficient?  any other input on additional mappings that may need to be called out here are welcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/410.html" title="Last updated on Mar 28, 2023, 5:04 PM UTC (f362e5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/410/e8d3b12...f362e5e.html" title="Last updated on Mar 28, 2023, 5:04 PM UTC (f362e5e)">Diff</a>