### PR TITLE
Editorial: pattern attribute - refer to core aam

### DIFF
--- a/index.html
+++ b/index.html
@@ -4829,31 +4829,16 @@
               <td class="elements">
                 <a data-cite="html/input.html#attr-input-pattern">`input`</a>
               </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `IA2_STATE_INVALID_ENTRY` if value doesn't meet the pattern
+              <td class="aria">
+                <div class="general">
+                  If the value doesn't match the pattern: <a class="core-mapping" href="#ariaInvalidTrue">`aria-invalid="true"`</a>;
+                  Otherwise, <a class="core-mapping" href="#ariaInvalidFalse">`aria-invalid="false"`</a>
                 </div>
               </td>
-              <td class="uia">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `IsDataValidForForm` if value doesn't meet the pattern
-                </div>
-              </td>
-              <td class="atk">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `ATK_STATE_INVALID_ENTRY` if value doesn't meet the pattern
-                </div>
-              </td>
-              <td class="ax">
-                <div class="property">
-                  <span class="type">Property:</span>
-                  `AXInvalid`: `true` if value doesn't meet the pattern
-                </div>
-              </td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-ping">


### PR DESCRIPTION
the pattern attribute maps to `aria-invalid` true and false states, but this was not directly stated in HTML AAM.  This PR corrects that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/411.html" title="Last updated on Jul 8, 2022, 8:39 PM UTC (f8c9b60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/411/a539165...f8c9b60.html" title="Last updated on Jul 8, 2022, 8:39 PM UTC (f8c9b60)">Diff</a>