### PR TITLE
Editorial: Clarify reversed attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -4988,22 +4988,22 @@
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2">
                 <div class="general">
-                  Reverses the numbering of the child list item accessible objects.
+                  Reverses the numerical or alphabetical order of the child list item markers.
                 </div>
               </td>
               <td class="uia">
                 <div class="general">
-                  Reverses the order of the child list items in the accessibility tree and reverses the numbering of the child list items.
+                  Reverses the numerical or alphabetical order of the child list item markers.
                 </div>
               </td>
               <td class="atk">
                 <div class="general">
-                  Reverses the numbering of the child list item accessible objects.
+                  Reverses the numerical or alphabetical order of the child list item markers.
                 </div>
               </td>
               <td class="ax">
                 <div class="general">
-                  Reverses the numbering of the child list markers.
+                  Reverses the numerical or alphabetical order of the child list item markers.
                 </div>
               </td>
               <td class="comments"></td>
@@ -5017,7 +5017,7 @@
               <td class="ia2"><div class="general">Not mapped</div></td>
               <td class="uia"><div class="general">Not mapped</div></td>
               <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax">Not mapped</td>
+              <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-rowspan">


### PR DESCRIPTION
Some of the text for the different platforms didn't align with what occurs in all browsers today (possibly there were variants in the past?)  

All mapping rows are now the same. `reversed` changes the list marker ordering (numeric or alphabetic) to be in reverse order, rather than starting with the lowest (1, A, etc) ordering marker.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 2, 2022, 2:36 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fhtml-aam%2F361452b694b5259957e5fb8c154cc024c5170755%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aam%23412.)._
</details>
