### PR TITLE
Addition: Revise address element to map to role=group

### DIFF
--- a/index.html
+++ b/index.html
@@ -6386,6 +6386,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
+          <li>19-Jul-2022: Update `address` element to be mapped to `role=group`. See <a href="https://github.com/w3c/html-aam/pull/420">GitHub PR 420</a></li>
           <li>03-Apr-2022: Update `aside` mappings based on its nesting context. See <a href="https://github.com/w3c/html-aam/pull/350">GitHub PR 350</a>.</li>
           <li>06-Mar-2022: Update the following elements to map to the `generic` role: `a no href`, `footer` not scoped to `body`, `header` not scoped to `body`, `samp`, `span`. See <a href="https://github.com/w3c/html-aam/pull/364">GitHub PR 364</a>.</li>
           <li>06-Feb-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>

--- a/index.html
+++ b/index.html
@@ -320,34 +320,13 @@
             </tr>
             <tr tabindex="-1" id="el-address">
               <th><a data-cite="HTML">`address`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span>
-                  `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-group">`group`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_SECTION`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-area">


### PR DESCRIPTION
Per discussion of `<address>` in #373, WG had no objections to mapping the element to the `group` role.

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=242699)
 * [x] Chromium - https://bugs.chromium.org/p/chromium/issues/detail?id=1342807
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1779252)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/420.html" title="Last updated on Jul 19, 2022, 1:54 PM UTC (e1e9de0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/420/58bd3ff...e1e9de0.html" title="Last updated on Jul 19, 2022, 1:54 PM UTC (e1e9de0)">Diff</a>