### PR TITLE
Correction: add missing label elm to 'button' naming steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -5927,6 +5927,9 @@
           <li>
             If the control has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
           </li>
+          <li>
+            Otherwise use the associated `label` element(s) <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>(s) - if more than one `label` is associated; concatenate by DOM order, delimited by spaces.
+          </li>
           <li>Otherwise use the `value` attribute.</li>
           <li>
             For `input type=submit`: If steps 1 to 2 do not yield a usable text string, the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is a localized string of the word &quot;submit&quot;.
@@ -5966,7 +5969,11 @@
           <li>
             If the control has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
           </li>
+          <li>
+            Otherwise use the associated `label` element(s) <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>(s) - if more than one `label` is associated; concatenate by DOM order, delimited by spaces.
+          </li>
           <li>Otherwise use `alt` attribute.</li>
+          <!-- NOTE: use of valid attribute is invalid on input type=image, but it DOES contribute to the name if used -->
           <!-- <li>Otherwise use `value` attribute.</li> -->
           <li>Otherwise use `title` attribute.</li>
           <li>
@@ -5999,6 +6006,9 @@
         <ol>
           <li>
             If the `button` element has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
+          </li>
+          <li>
+            Otherwise use the associated `label` element(s) <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>(s) - if more than one `label` is associated; concatenate by DOM order, delimited by spaces.
           </li>
           <li>Otherwise use the `button` element subtree.</li>
           <li>Otherwise use `title` attribute.</li>


### PR DESCRIPTION
adds label element to `button`, `input type=button|submit|reset|image`.

This is a long overdue update and there could be more clarity here.  However, getting this perfect has long stood in the way of getting this done, and I would rather get this gap resolved to match reality, and then better describe this in a follow revision to these naming steps.

Closes #357 - companion PR to #402


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/423.html" title="Last updated on Jul 19, 2022, 2:00 PM UTC (b7aa00b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/423/4310e8d...b7aa00b.html" title="Last updated on Jul 19, 2022, 2:00 PM UTC (b7aa00b)">Diff</a>