### PR TITLE
update mappings for pre and q elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2440,43 +2440,13 @@
             </tr>
             <tr tabindex="-1" id="el-pre">
               <th><a data-cite="html">`pre`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GROUPING`; `IA2_ROLE_SECTION`
-                </div>
-                <div class="general">
-                  Styles used are mapped to text attributes on the parent accessible object.
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"pre"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span>
-                  `ATK_ROLE_SECTION`
-                </div>
-                <div class="general">
-                  Styles used are mapped to text attributes on the accessible object.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-progress">
@@ -2494,41 +2464,16 @@
             </tr>
             <tr tabindex="-1" id="el-q">
               <th><a data-cite="HTML">`q`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                </div>
-                <div class="children">
-                  <span class="type">Children:</span> `ROLE_SYSTEM_TEXT` wrapped by quote marks using `ROLE_SYSTEM_STATICTEXT`
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"q"`
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                `::before` and `::after` CSS pseudo content is used by platforms to render the element's quotation marks.
               </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span>
-                  `ATK_ROLE_STATIC`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <td class="comments"></td>
             </tr>
             <!--
               *** Marked as obsolete in HTML. ***


### PR DESCRIPTION
updates the mappings to `generic` as discussed by the WG.

related to issue #373


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/424.html" title="Last updated on Jul 8, 2022, 9:36 PM UTC (a9f2d63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/424/b827497...a9f2d63.html" title="Last updated on Jul 8, 2022, 9:36 PM UTC (a9f2d63)">Diff</a>