### PR TITLE
Mapping updates for generic elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,23 +369,13 @@
                 <a data-cite="HTML">`area`</a>
                 <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_SHAPE`
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-article">
@@ -490,34 +480,16 @@
               <th>
                 <a data-cite="HTML">`b`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. Exposed as "font-weight" text attribute on the text container. The value depends on the platform.
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object. Exposed by the `FontWeight` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                Exposed by platform specific bold font weight text styles.
               </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as "font-weight" text attribute on the text container. The value depends on the platform.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-base">
               <th>
@@ -534,60 +506,31 @@
               <th>
                 <a data-cite="HTML">`bdi`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. May affect on "writing-mode" text attribute on its text container.
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                IA2/ATK: May affect on "writing-mode" text attribute on its text container.
               </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. May affect on "writing-mode" text attribute on its text container.
-                </div>
-              </td>
-              <td class="ax"></td>
-              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-bdo">
               <th>
                 <a data-cite="HTML">`bdo`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`
-                </div>
-                <div class="properties">
-                  <span class="type">Text attributes:</span> `writing-mode` on the text container
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                IA2/ATK: Exposed as "writing-mode" text attribute on its text container.
               </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as "writing-mode" text attribute on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-blockquote">
               <th>
@@ -614,21 +557,11 @@
             <tr tabindex="-1" id="el-br">
               <th><a data-cite="HTML">`br`</a></th>
               <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. Exposed as '\n' character
-                  via `IAccessibleText2` interface on the text container.
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
               <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as '\n' character
-                  via `AtkText` interface on the text container.
-                </div>
-              </td>
+              <td class="atk"><div class="general">Not mapped</div></td>
               <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
+              <td class="comments">May be exposed as '\n' character by the platform interface.</td>
             </tr>
             <tr tabindex="-1" id="el-button">
               <th>
@@ -801,11 +734,13 @@
               <th>
                 <a data-cite="HTML">`data`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-datalist">
@@ -1295,34 +1230,16 @@
               <th>
                 <a data-cite="HTML">`i`</a>
               </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">No accessible object.</div>
-                <div class="properties">
-                  <span class="type">Text attributes:</span> `font-style:italic` on the text container
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="general">No accessible object. Exposed by the `IsItalic` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                Exposed by platform specific italic text styles.
               </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as "font-style:italic" text attribute on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-iframe">
               <th>
@@ -2798,35 +2715,16 @@
             </tr>
             <tr tabindex="-1" id="el-small">
               <th><a data-cite="HTML">`small`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">No accessible object.</div>
-                <div class="properties">
-                  <span class="type">Text attributes:</span> `font-size` on the text container
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="general">No accessible object. Exposed by `FontSize` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                Exposed by platform specific font size styles.
               </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Exposed as "font-size"
-                  text attribute on the text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-source">
               <th><a data-cite="HTML">`source`</a></th>
@@ -3143,22 +3041,16 @@
             </tr>
             <tr tabindex="-1" id="el-u">
               <th><a data-cite="HTML">`u`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">No accessible object. Exposed as "text-underline-style:solid" text attribute on its text container.
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
               </td>
-              <td class="uia">
-                <div class="general">No accessible object. Exposed by `UnderlineStyle` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                Exposed by platform specific underline text styles.
               </td>
-              <td class="atk">
-                <div class="general">No accessible object. Exposed as
-                  "text-underline-style:solid" text attribute on its text container.
-                </div>
-              </td>
-              <td class="ax">Not mapped</td>
-              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-ul">
               <th><a data-cite="HTML">`ul`</a></th>


### PR DESCRIPTION
i, u, b, small map to generic.  Comments referring to the elements being exposed by their platform specific text styles remain in comments.

bdi/bdo map to generic. Reference writing-mode properties in comments for ia2/atk

`data` and `a no href` map to generic as decided.

also: simplifies br element mapping table

companion PR: #424

merging this pr and 424 will close #373


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/426.html" title="Last updated on Jul 9, 2022, 5:19 PM UTC (e584450)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/426/9cdaf74...e584450.html" title="Last updated on Jul 9, 2022, 5:19 PM UTC (e584450)">Diff</a>