### PR TITLE
Clarify summary role when not properly used

### DIFF
--- a/index.html
+++ b/index.html
@@ -2887,7 +2887,10 @@
                 </div>
               </td>
               <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
+              <td class="comments">
+                If a `summary` element is not a child of a `details` element, or it is not the first `summary` element of a parent `details`, 
+                then the `summary` element MUST be exposed with a `generic` role.
+              </td>
             </tr>
             <tr tabindex="-1" id="el-sup">
               <th><a data-cite="html">`sup`</a></th>


### PR DESCRIPTION
A `summary` element used outside of a `details` parent, or invalid extra `summary` elements within a `details` element need to NOT be exposed as an interactive element.

Chromium browsers correctly re-map the errant `summary` element(s) to `role=generic`.  Firefox and Webkit continue to expose them as interactive elements, thought hey are not.

```html
<body>
  <summary>oops!</summary>

  <!-- or -->
  <details>
     <summary>I'm valid</summary>
     <summary>I'm just wrong</summary>
     ...
  </details>
</body> 
```

A test example: https://codepen.io/scottohara/pen/poVyeNV

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=244973)
 * [x] Chromium (already does this correctly)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1790056)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/436.html" title="Last updated on Mar 8, 2023, 2:53 PM UTC (990181e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/436/86dd996...990181e.html" title="Last updated on Mar 8, 2023, 2:53 PM UTC (990181e)">Diff</a>