### PR TITLE
update s element mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -2659,33 +2659,13 @@
             </tr>
             <tr tabindex="-1" id="el-s">
               <th><a data-cite="HTML">`s`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="general">No accessible object.</div>
-                <div class="properties">
-                  <span class="type">Text attributes:</span> `text-line-through-style:solid` on the text container
-                </div>
+              <td class="aria">
+                <a class="core-mapping" href="#role-map-deletion">`deletion`</a> role
               </td>
-              <td class="uia">
-                <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">No accessible object. Exposed as
-                  "text-line-through-style:solid" text attribute on the text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <!-- <td class="naming"></td> -->
               <td class="comments"></td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -6128,6 +6128,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
+          <li>12-Dec-2022: Revise mapping for `s` element to be `role=deletion`. See <a href="https://github.com/w3c/html-aam/pull/442">GitHub PR 442</a>.</li>
           <li>28-Nov-2022: Simplify accessible description computation section. See <a href="https://github.com/w3c/html-aam/pull/444">GitHub PR 444</a>.</li>
           <li>19-Jul-2022: Update `address` element to be mapped to `role=group`. See <a href="https://github.com/w3c/html-aam/pull/420">GitHub PR 420</a>.</li>
           <li>03-Apr-2022: Update `aside` mappings based on its nesting context. See <a href="https://github.com/w3c/html-aam/pull/350">GitHub PR 350</a>.</li>


### PR DESCRIPTION
closes #416 

revises the `<s>` element to map to ARIA's `deletion` role, rather than having no implicit ARIA mapping. Introducing this mapping would allow for browsers to expose this role, and thus AT to better communicate that the content is marked as no longer relevant.  Presently authors need to employ visually hidden content to programmatically convey what the element visually represents with its default UA CSS strike-through.

## Implementation requests:
   * WebKit: [ISSUE: 246745](https://bugs.webkit.org/show_bug.cgi?id=246745)
   * Gecko: [ISSUE: 1796178](https://bugzilla.mozilla.org/show_bug.cgi?id=1796178)
   * Blink: [ISSUE: 1376572](https://bugs.chromium.org/p/chromium/issues/detail?id=1376572)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/442.html" title="Last updated on Dec 12, 2022, 5:40 PM UTC (599960a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/442/e3a102a...599960a.html" title="Last updated on Dec 12, 2022, 5:40 PM UTC (599960a)">Diff</a>