### PR TITLE
update reference to placeholder in naming computation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5853,7 +5853,7 @@
             Otherwise use the associated `label` element(s) <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>(s) - if more than one label is associated; concatenate by DOM order, delimited by spaces.
           </li>
           <li>If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: use the control's `title` attribute.</li>
-          <li>Otherwise use the control's <code>placeholder</code> attribute.</li>
+          <li>Otherwise use the control's <a href="#att-placeholder">placeholder</a> value.</li>
           <li>
             If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
           </li>


### PR DESCRIPTION
related to https://github.com/w3c/accname/issues/17

In terms of how naming is calculated, because `placeholder` is included as the last-resort option for naming, that means that `aria-placeholder` is too.  So, without calling that out explicitly (because we absolutely don't want to make it seem that naming an element via `aria-placeholder` is at all a proper thing to do), instead slightly reword the step to allude to using the placeholder value instead of the attribute itself.  The placeholder text now links to the attribute, which indicates it maps to the aria-placeholder property... so, a very roundabout way of calling this out, but roundabout on purpose.

The alternative to this is we just list `placeholder` and `aria-placeholder` and indicate that's the order of preference - HTML feature over ARIA if both are present.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/443.html" title="Last updated on Oct 27, 2022, 7:04 PM UTC (daa680d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/443/a5ada74...daa680d.html" title="Last updated on Oct 27, 2022, 7:04 PM UTC (daa680d)">Diff</a>