### PR TITLE
further alignment with accName description updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -6148,7 +6148,8 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
-          <li>19-Jul-2022: Update `address` element to be mapped to `role=group`. See <a href="https://github.com/w3c/html-aam/pull/420">GitHub PR 420</a></li>
+          <li>28-Nov-2022: Simplify accessible description computation section. See <a href="https://github.com/w3c/html-aam/pull/444">GitHub PR 444</a>.</li>
+          <li>19-Jul-2022: Update `address` element to be mapped to `role=group`. See <a href="https://github.com/w3c/html-aam/pull/420">GitHub PR 420</a>.</li>
           <li>03-Apr-2022: Update `aside` mappings based on its nesting context. See <a href="https://github.com/w3c/html-aam/pull/350">GitHub PR 350</a>.</li>
           <li>06-Mar-2022: Update the following elements to map to the `generic` role: `a no href`, `footer` not scoped to `body`, `header` not scoped to `body`, `samp`, `span`. See <a href="https://github.com/w3c/html-aam/pull/364">GitHub PR 364</a>.</li>
           <li>06-Feb-2022: Update `mark` to point to Core AAM mapping for the role. See <a href="https://github.com/w3c/html-aam/issues/316">GitHub Issue 316</a>.</li>

--- a/index.html
+++ b/index.html
@@ -6100,30 +6100,42 @@
     </section>
     <section id="accdesc-computation">
       <h3>Accessible Description Computation</h3>
-      <p>An <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> MAY be provided to any HTML element that is a valid child of the `body` element.</p>
+      <p>
+        An <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> MAY be provided to any HTML element that is a valid child of 
+        the `body` element. The following list represents the order of precedence for <a class="termref">user agents</a> to compute the 
+        <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> of an element. As defined by 
+        <a data-cite="accname-1.2/#mapping_additional_nd_description">Accessible Name and Description Computation: Description Computation </a>, 
+        <a class="termref">user agents</a> MUST use the first applicable description source, even if its use results in an empty description.
+      </p>
       <ol>
         <li>
-          If the element has an <a data-cite="wai-aria-1.2/#aria-describedby">`aria-describedby`</a> or <a href="https://w3c.github.io/aria/#aria-description">`aria-description`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
+          If the element has an <a data-cite="wai-aria-1.2/#aria-describedby">`aria-describedby`</a> or 
+          <a href="https://w3c.github.io/aria/#aria-description">`aria-description`</a> attribute refer to the computation conditions defined in 
+          <a data-cite="accname-1.2/#mapping_additional_nd_description">Accessible Name and Description: Computation and API Mappings</a>.
         </li>
         <li>
           Otherwise, if the <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> is still empty, and the element is:
           <ul>
             <li>
-              a `table` element which has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> `caption` element, use the subtree of the first `caption` element if it was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
+              a `table` element which has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> `caption` element, use the 
+              <a data-cite="accname-1.2/#mapping_additional_nd_te">text equivalent computation</a> of the subtree of the first `caption` element if it 
+              was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>. 
             </li>
             <li>
-              a `summary` element, use the element's subtree if it was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
+              a `summary` element, use the <a data-cite="accname-1.2/#mapping_additional_nd_te">text equivalent computation</a> of its subtree if it was not 
+              used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
             </li>
             <li>
-              an `input` element whose `type` attribute is the `button`, `submit` or `reset` state, and it has a `value` attribute, then use the content of the attribute if it was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
+              an `input` element whose `type` attribute is the `button`, `submit` or `reset` state, and it has a `value` attribute, then use the flat string 
+              of the attribute if it was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
             </li>
           </ul>
         </li> 
         <li>
-          Otherwise, use the content of the `title` attribute if it was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for the element.
+          Otherwise, use the flat string of the `title` attribute if it was not used as the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for the element.
         </li>
         <li>
-          If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>.
+          If none of the above are applicable, there is no <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>.
         </li>
       </ol>
     </section>


### PR DESCRIPTION
This PR is necessary to fully address the needs of the accName PR - https://github.com/w3c/accname/pull/69

- New language has been added to the introduction of this section, better aligning it with the normative text of accName's new 4.2 section.
- cut down item 1 the text was redundant per the new language added to the introduction of the section.
- Modified each of the section 2 items to align with the accName table column "how to compute description".
- Revised the final item (4) to align with the accName normative text, and the revised introduction of this section, stating that UAs are even expected to return an empty description.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/444.html" title="Last updated on Nov 28, 2022, 9:34 PM UTC (1a21ba6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/444/45c9b49...1a21ba6.html" title="Last updated on Nov 28, 2022, 9:34 PM UTC (1a21ba6)">Diff</a>