### PR TITLE
Adds proposed popover and related attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4928,8 +4928,7 @@
             <tr tabindex="-1" id="att-popoverhidetarget">
               <th>`popoverhidetarget`</th>
               <td class="elements">
-              	<a >`button</a>;
-                <a >`button type=button`</a>;
+              	<a >`button`</a>;
                 <a >`input type=button`</a>
               </td>
               <td class="aria"><div class="general">
@@ -4942,7 +4941,7 @@
               <td class="atk">Use WAI-ARIA mapping</td>
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
-              	<p>The attribute is supported on a `button` element without a specified `type` as long as the `button` would not otherwise submit a form. In such an instance user agents MUST ignore the attribute.</p>
+              	<p>The attribute is supported on a `button` element regardless of the specified `type` so long as the `button` would not otherwise submit or reset a form. In such an instance user agents MUST ignore the attribute.</p>
 
               	<!-- defaults to the expanded state? Should map to 'disabled' when the popover is hidden? -->
 
@@ -4954,8 +4953,7 @@
             <tr tabindex="-1" id="att-popovershowtarget">
               <th>`popovershowtarget`</th>
               <td class="elements">
-              	<a >`button</a>;
-                <a >`button type=button`</a>;
+              	<a >`button`</a>;
                 <a >`input type=button`</a>
               </td>
               <td class="aria"><div class="general"> 
@@ -4968,7 +4966,7 @@
               <td class="atk">Use WAI-ARIA mapping</td>
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
-              	<p>The attribute is supported on a `button` element without a specified `type` as long as the `button` would not otherwise submit a form. In such an instance user agents MUST ignore the attribute.</p>
+              	<p>The attribute is supported on a `button` element regardless of the specified `type` so long as the `button` would not otherwise submit or reset a form. In such an instance user agents MUST ignore the attribute.</p>
 
               	<!-- defaults to the collapsed state? Should map to 'disabled' when the popover is shown? -->
 
@@ -4980,8 +4978,7 @@
             <tr tabindex="-1" id="att-popovertoggletarget">
               <th>`popovertoggletarget`</th>
               <td class="elements">
-              	<a >`button</a>;
-                <a >`button type=button`</a>;
+              	<a >`button`</a>;
                 <a >`input type=button`</a>
               </td>
               <td class="aria"><div class="general">
@@ -4994,7 +4991,7 @@
               <td class="atk">Use WAI-ARIA mapping</td>
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
-              	<p>The attribute is supported on a `button` element without a specified `type` as long as the `button` would not otherwise submit a form. In such an instance user agents MUST ignore the attribute.</p>
+              	<p>The attribute is supported on a `button` element regardless of the specified `type` so long as the `button` would not otherwise submit or reset a form. In such an instance user agents MUST ignore the attribute.</p>
 
               	<p>Defaults to the  state (`aria-expanded=false`). If the ID referenced element with the `popover` attribute also has a `defaultopen` attribute, then defaults to the expanded state (`aria-expanded=true`).</p>
               	

--- a/index.html
+++ b/index.html
@@ -3837,22 +3837,6 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="att-defaultopen">
-              <th>`defaultopen`</th>
-              <td class="elements">
-                <a >HTML elements</a>
-              </td>
-              <td class="aria"><div class="general"> Not mapped </div></td>
-              <td class="ia2"><div class="general"> Not mapped </div></td>
-              <td class="uia"><div class="general" Not mapped </div></td>
-              <td class="atk"><div class="general"> Not mapped </div></td>
-              <td class="ax"><div class="general"> Not mapped </div></td>
-              <td class="comments">
-              	<p>When used on an element which also has the `popover` attribute, the user agent will show the popover by default. 
-                  Any element with a `popovertoggletarget`, `popovershowtarget` or `popoverhidetarget` attribute that references the rendered popover 
-                  MUST also default to the expanded state to match the popover's revealed state.</p>
-              </td>
-            </tr>
             <tr tabindex="-1" id="att-defer">
               <th>`defer`</th>
               <td class="elements">

--- a/index.html
+++ b/index.html
@@ -4942,11 +4942,7 @@
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
               	<p>The attribute is supported on a `button` element regardless of the specified `type` so long as the `button` would not otherwise submit or reset a form. In such an instance user agents MUST ignore the attribute.</p>
-
-              	<!-- defaults to the expanded state? Should map to 'disabled' when the popover is hidden? -->
-
               	<p>The expanded or collapsed state MUST reflect the state of the ID referenced element with the `popover` attribute.</p>
-
               	<p>If there is no element with an ID matching the specified value of the attribute, then the attribute maps to the `undefined` state.</p>
               </td>
             </tr>
@@ -4967,11 +4963,7 @@
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
               	<p>The attribute is supported on a `button` element regardless of the specified `type` so long as the `button` would not otherwise submit or reset a form. In such an instance user agents MUST ignore the attribute.</p>
-
-              	<!-- defaults to the collapsed state? Should map to 'disabled' when the popover is shown? -->
-
               	<p>The expanded or collapsed state MUST reflect the state of the ID referenced element with the `popover` attribute.</p>
-
               	<p>If there is no element with an ID matching the specified value of the attribute, then the attribute maps to the `undefined` state.</p>
               </td>
             </tr>
@@ -4992,11 +4984,8 @@
               <td class="ax">Use WAI-ARIA mapping</td>
               <td class="comments">
               	<p>The attribute is supported on a `button` element regardless of the specified `type` so long as the `button` would not otherwise submit or reset a form. In such an instance user agents MUST ignore the attribute.</p>
-
               	<p>Defaults to the  state (`aria-expanded=false`). If the ID referenced element with the `popover` attribute also has a `defaultopen` attribute, then defaults to the expanded state (`aria-expanded=true`).</p>
-              	
               	<p>The expanded or collapsed state MUST reflect the state of the ID referenced element with the `popover` attribute.</p>
-
               	<p>If there is no element with an ID matching the specified value of the attribute, then the attribute maps to the `undefined` state.</p>
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -4933,7 +4933,7 @@
               </td>
               <td class="aria"><div class="general"> TODO </div></td>
               <td class="ia2"><div class="general"> TODO </div></td>
-              <td class="uia"><div class="general" TODO </div></td>
+              <td class="uia"><div class="general"> TODO </td>
               <td class="atk"><div class="general"> TODO </div></td>
               <td class="ax"><div class="general"> TODO </div></td>
               <td class="comments">

--- a/index.html
+++ b/index.html
@@ -3837,6 +3837,22 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
+            <tr tabindex="-1" id="att-defaultopen">
+              <th>`defaultopen`</th>
+              <td class="elements">
+                <a >HTML elements</a>
+              </td>
+              <td class="aria"><div class="general"> Not mapped </div></td>
+              <td class="ia2"><div class="general"> Not mapped </div></td>
+              <td class="uia"><div class="general" Not mapped </div></td>
+              <td class="atk"><div class="general"> Not mapped </div></td>
+              <td class="ax"><div class="general"> Not mapped </div></td>
+              <td class="comments">
+              	<p>When used on an element which also has the `popover` attribute, the user agent will show the popover by default. 
+                  Any element with a `popovertoggletarget`, `popovershowtarget` or `popoverhidetarget` attribute that references the rendered popover 
+                  MUST also default to the expanded state to match the popover's revealed state.</p>
+              </td>
+            </tr>
             <tr tabindex="-1" id="att-defer">
               <th>`defer`</th>
               <td class="elements">
@@ -4909,6 +4925,99 @@
               <td class="atk"><div class="general">Not mapped</div></td>
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-popover">
+              <th>`popover`</th>
+              <td class="elements">
+                <a >HTML elements</a>
+              </td>
+              <td class="aria"><div class="general"> TODO </div></td>
+              <td class="ia2"><div class="general"> TODO </div></td>
+              <td class="uia"><div class="general" TODO </div></td>
+              <td class="atk"><div class="general"> TODO </div></td>
+              <td class="ax"><div class="general"> TODO </div></td>
+              <td class="comments">
+              	<p>User agents MUST ignore the `popover` attribute when used on a `dialog` element that is rendered via `showModal()`. A non-modal dialog MAY be rendered as a popover.</p>
+              </td>
+            </tr>
+
+            <tr tabindex="-1" id="att-popoverhidetarget">
+              <th>`popoverhidetarget`</th>
+              <td class="elements">
+              	<a >`button</a>;
+                <a >`button type=button`</a>;
+                <a >`input type=button`</a>
+              </td>
+              <td class="aria"><div class="general">
+              	<a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded=true`</a>,
+              	<a class="core-mapping" href="#ariaExpandedFalse">`false`</a> or
+              	<a class="core-mapping" href="#ariaExpandedUndefined">`undefined`</a>
+              </td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments">
+              	<p>The attribute is supported on a `button` element without a specified `type` as long as the `button` would not otherwise submit a form. In such an instance user agents MUST ignore the attribute.</p>
+
+              	<!-- defaults to the expanded state? Should map to 'disabled' when the popover is hidden? -->
+
+              	<p>The expanded or collapsed state MUST reflect the state of the ID referenced element with the `popover` attribute.</p>
+
+              	<p>If there is no element with an ID matching the specified value of the attribute, then the attribute maps to the `undefined` state.</p>
+              </td>
+            </tr>
+            <tr tabindex="-1" id="att-popovershowtarget">
+              <th>`popovershowtarget`</th>
+              <td class="elements">
+              	<a >`button</a>;
+                <a >`button type=button`</a>;
+                <a >`input type=button`</a>
+              </td>
+              <td class="aria"><div class="general"> 
+              	<a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded=true`</a>,
+              	<a class="core-mapping" href="#ariaExpandedFalse">`false`</a> or
+              	<a class="core-mapping" href="#ariaExpandedUndefined">`undefined`</a>
+              </td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments">
+              	<p>The attribute is supported on a `button` element without a specified `type` as long as the `button` would not otherwise submit a form. In such an instance user agents MUST ignore the attribute.</p>
+
+              	<!-- defaults to the collapsed state? Should map to 'disabled' when the popover is shown? -->
+
+              	<p>The expanded or collapsed state MUST reflect the state of the ID referenced element with the `popover` attribute.</p>
+
+              	<p>If there is no element with an ID matching the specified value of the attribute, then the attribute maps to the `undefined` state.</p>
+              </td>
+            </tr>
+            <tr tabindex="-1" id="att-popovertoggletarget">
+              <th>`popovertoggletarget`</th>
+              <td class="elements">
+              	<a >`button</a>;
+                <a >`button type=button`</a>;
+                <a >`input type=button`</a>
+              </td>
+              <td class="aria"><div class="general">
+              	<a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded=true`</a>,
+              	<a class="core-mapping" href="#ariaExpandedFalse">`false`</a> or
+              	<a class="core-mapping" href="#ariaExpandedUndefined">`undefined`</a>
+              </td>
+              <td class="ia2">Use WAI-ARIA mapping</td>
+              <td class="uia">Use WAI-ARIA mapping</td>
+              <td class="atk">Use WAI-ARIA mapping</td>
+              <td class="ax">Use WAI-ARIA mapping</td>
+              <td class="comments">
+              	<p>The attribute is supported on a `button` element without a specified `type` as long as the `button` would not otherwise submit a form. In such an instance user agents MUST ignore the attribute.</p>
+
+              	<p>Defaults to the  state (`aria-expanded=false`). If the ID referenced element with the `popover` attribute also has a `defaultopen` attribute, then defaults to the expanded state (`aria-expanded=true`).</p>
+              	
+              	<p>The expanded or collapsed state MUST reflect the state of the ID referenced element with the `popover` attribute.</p>
+
+              	<p>If there is no element with an ID matching the specified value of the attribute, then the attribute maps to the `undefined` state.</p>
+              </td>
             </tr>
             <tr tabindex="-1" id="att-poster">
               <th>`poster`</th>


### PR DESCRIPTION
See https://open-ui.org/components/popup.research.explainer and https://github.com/w3c/html-aam/wiki/HTML-Popover-Attribute-A11y-Proposal-(manual-and-auto)

Adds the following proposed attributes:
- `popover`
- `popoverhidetarget`
- `popovershowtarget`
- `popovertoggletarget`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/446.html" title="Last updated on Feb 23, 2023, 6:35 PM UTC (c8b66f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/446/0323bc1...c8b66f5.html" title="Last updated on Feb 23, 2023, 6:35 PM UTC (c8b66f5)">Diff</a>