### PR TITLE
Clarification: label element and for attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -2101,7 +2101,7 @@
                 </div>
                 <div class="relations">
                   <span class="type">Relations:</span> 
-                  `IA2_RELATION_LABEL_FOR` with a <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
+                  `IA2_RELATION_LABEL_FOR` with a <a data-cite="html/forms.html#category-label">labelable element</a>
                   that is child to the `label` or referred to by the `label` element's <a href="#att-for-label">`for`</a> attribute. 
                   The associated labelable element has `IA2_RELATION_LABELLED_BY` pointing to the `label`.
                 </div>
@@ -2112,13 +2112,15 @@
                 </div>
                 <div class="properties">
                   <span class="type">Other properties:</span>
-                  When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for 
-                  the element points to the UIA element for the `label` element.
-                  <p>
+                  <div>
+                    When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for 
+                    the element points to the UIA element for the `label` element.
+                  </div>
+                  <div>
                     When the `label` element has a <a href="#att-for-label">`for`</a> attribute referencing a  
                     <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for the referenced element points to 
                     the UIA element for the `label` element.
-                  </p>
+                  </div>
                 </div>
               </td>
               <td class="atk">
@@ -2126,9 +2128,10 @@
                   <span class="type">Role:</span> `ATK_ROLE_LABEL`
                 </div>
                 <div class="relations">
-                  <span class="type">Relations: </span>
-                  `ATK_RELATION_LABEL_FOR` for a child form element or form element referred by <a href="#att-for-label">`for`</a> attribute. 
-                  Note, related form element provides `ATK_RELATION_LABELLED_BY` pointing to the label.
+                  <span class="type">Relations:</span>
+                  `ATK_RELATION_LABEL_FOR` for a child <a data-cite="html/forms.html#category-label">labelable element</a> or 
+                  labelable element referred by <a href="#att-for-label">`for`</a> attribute. 
+                  Note, related labelable element provides `ATK_RELATION_LABELLED_BY` pointing to the `label`.
                 </div>
               </td>
               <td class="ax">

--- a/index.html
+++ b/index.html
@@ -2113,7 +2113,7 @@
                   <span class="type">Control Type:</span> `Text`
                 </div>
                 <div class="properties">
-                  <span class="type">Other properties:</span>
+                  <span class="type">Relations:</span> 
                   <div>
                     When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for 
                     the element points to the UIA element for the `label` element.

--- a/index.html
+++ b/index.html
@@ -2112,7 +2112,7 @@
                 <div class="ctrltype">
                   <span class="type">Control Type:</span> `Text`
                 </div>
-                <div class="properties">
+                <div>
                   <span class="type">Relations:</span> 
                   <div>
                     When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for 

--- a/index.html
+++ b/index.html
@@ -2100,7 +2100,10 @@
                   <span class="type">Roles:</span> `ROLE_SYSTEM_STATICTEXT`; `IA2_ROLE_LABEL`
                 </div>
                 <div class="relations">
-                  <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with a form control that is child to the `label` or referred to by the `label` element's <a href="#att-for-label">`for`</a> attribute. The associated form element has `IA2_RELATION_LABELLED_BY` pointing to the `label`.
+                  <span class="type">Relations:</span> 
+                  `IA2_RELATION_LABEL_FOR` with a <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
+                  that is child to the `label` or referred to by the `label` element's <a href="#att-for-label">`for`</a> attribute. 
+                  The associated labelable element has `IA2_RELATION_LABELLED_BY` pointing to the `label`.
                 </div>
               </td>
               <td class="uia">
@@ -2109,8 +2112,13 @@
                 </div>
                 <div class="properties">
                   <span class="type">Other properties:</span>
-                  When the `label` element contains an `input` element, the `LabeledBy` property for the `input` element points to the UIA element for the `label` element.
-                  <p>When the `label` element has a <a href="#att-for-label">`for`</a> attribute referencing another element, the `LabeledBy` property for the referenced element points to the UIA element for the `label` element.</p>
+                  When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for 
+                  the element points to the UIA element for the `label` element.
+                  <p>
+                    When the `label` element has a <a href="#att-for-label">`for`</a> attribute referencing a  
+                    <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for the referenced element points to 
+                    the UIA element for the `label` element.
+                  </p>
                 </div>
               </td>
               <td class="atk">
@@ -2119,7 +2127,8 @@
                 </div>
                 <div class="relations">
                   <span class="type">Relations: </span>
-                  `ATK_RELATION_LABEL_FOR` for a child form element or form element referred by <a href="#att-for-label">`for`</a> attribute. Note, related form element provides `ATK_RELATION_LABELLED_BY` pointing to the label.
+                  `ATK_RELATION_LABEL_FOR` for a child form element or form element referred by <a href="#att-for-label">`for`</a> attribute. 
+                  Note, related form element provides `ATK_RELATION_LABELLED_BY` pointing to the label.
                 </div>
               </td>
               <td class="ax">
@@ -3954,7 +3963,7 @@
             <tr tabindex="-1" id="att-for-label">
               <th>`for`</th>
               <td class="elements">
-                <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-label-for">`label`</a>
+                <a data-cite="html/forms.html#attr-label-for">`label`</a>
               </td>
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2">
@@ -3964,10 +3973,18 @@
                 <div class="relations">
                   <span class="type">Relations: </span>
                   `IA2_RELATION_LABEL_FOR` and `IA2_RELATION_LABEL_BY` relations between
-                  <a href="#el-label">`label`</a> and referred element
+                  <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
                 </div>
               </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="uia">
+                <div class="name">
+                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+                </div>
+                <div class="relations">
+                  When the `label` element has a `for` attribute referencing another <a data-cite="html/forms.html#category-label">labelable element</a>,
+                  the `LabeledBy` property for the referenced element points to the UIA element for the `label` element.
+                </div>
+              </td>
               <td class="atk">
                 <div class="name">
                   Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
@@ -3975,10 +3992,14 @@
                 <div class="relations">
                   <span class="type">Relations: </span>
                   `ATK_RELATION_LABEL_FOR` and `ATK_RELATION_LABEL_BY` relations between
-                  <a href="#el-label">`label`</a> and referred element
+                  <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
                 </div>
               </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="ax">
+                <div class="name">
+                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+                </div>
+              </td>
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-for-output">


### PR DESCRIPTION
This PR clarifies some of the wording in the `label` element mappings where, for instance, UIA was written in a way that was specifically calling out labelling the `input` element - but there are a number of labelable elements that are not `input`.  Rather than say all of them or even say 'form controls' which is also not necessarily accurate, instead mention and link to the HTML spec's definition and listing of labelable elements.

The `label[for]` attribute was updated to consistently indicate that it's used for accname by all the platforms.  UIA's 'not mapped' text was replaced with a version of the text that existed in the `label` element's UIA mapping.  MSAA/IA2 mappings were updated to reference the labelable element section from HTML.

note: this work was done as I noticed these things needed clarifying while making other additions to #402 today.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/448.html" title="Last updated on Mar 22, 2023, 12:36 PM UTC (91a8276)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/448/472383b...91a8276.html" title="Last updated on Mar 22, 2023, 12:36 PM UTC (91a8276)">Diff</a>