### PR TITLE
Remove references to "sectioning root"

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,8 +402,7 @@
             <tr tabindex="-1" id="el-aside">
               <th>
                 <a data-cite="HTML">`aside`</a>
-                (scoped to a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element,
-                or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than `body`)
+                (scoped to a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role if the <a>`aside`</a> element has an <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
@@ -1102,8 +1101,7 @@
             <tr tabindex="-1" id="el-footer">
               <th>
                 <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element,
-                a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element,
-                or a <a data-cite="HTML/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="HTML">`body`</a>)
+                a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-generic">`generic`</a> role
@@ -1204,7 +1202,7 @@
             </tr>
             <tr tabindex="-1" id="el-header">
               <th>
-                <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`main`</a> element, a <a data-cite="html/dom.html#sectioning-content">sectioning content</a> element, or a <a data-cite="html/sections.html#sectioning-root">sectioning root</a> element other than <a data-cite="html">`body`</a>)
+                <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`main`</a> element, or a <a data-cite="html/dom.html#sectioning-content">sectioning content</a> element)
               </th>
               <td class="aria">
                 <a class="core-mapping" href="#role-map-generic">`generic`</a> role


### PR DESCRIPTION
Sectioning root was removed from HTML here: https://github.com/whatwg/html/pull/7829
So this PR updates CORE-AAM to match the authors guidance here: https://w3c.github.io/html-aria/#el-header
And we separately discussed that the "sectioning root" check was unnecessary here: https://github.com/w3c/html-aam/issues/375#issuecomment-1111553801

This doesn't close the issue #375 because scoped is still not defined.

## Implementation

* WPT tests: [LINK]()
* Implementations (link to issue or when done, link to commit):
   * WebKit: [ISSUE]()
   * Gecko: [ISSUE]()
   * Blink: [ISSUE]()


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/456.html" title="Last updated on Jan 24, 2023, 5:03 PM UTC (cb58c1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/456/2de152d...cb58c1b.html" title="Last updated on Jan 24, 2023, 5:03 PM UTC (cb58c1b)">Diff</a>