### PR TITLE
Clarification: clarify checked mapping tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -3535,7 +3535,7 @@
             <tr tabindex="-1" id="att-checked">
               <th>`checked` (if present)</th>
               <td class="elements">
-                <a data-cite="html/input.html#attr-input-checked">`input`</a>
+                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checked` or `type=radio`
               </td>
               <td class="aria">
                 <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="true"
@@ -3545,13 +3545,14 @@
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax">`AXValue: 1`</td>
               <td class="comments">
-                If the element includes both the `checked` attribute and the `aria-checked` attribute with a valid value, User Agents MUST expose only the `checked` attribute value.
+                If an `input` element in the `checkbox` or `radio` state includes both the `checked` attribute and the `aria-checked` attribute with a 
+                valid value, User Agents MUST expose only the `checked` attribute value.
               </td>
             </tr>
             <tr tabindex="-1" id="att-checked-absent">
               <th>`checked` (if absent)</th>
               <td class="elements">
-                <a data-cite="html/input.html#attr-input-checked">`input`</a>
+                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checked` or `type=radio`
               </td>
               <td class="aria">
                 <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a> (state)="false"
@@ -3561,8 +3562,8 @@
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax">`AXValue: 0`</td>
               <td class="comments">
-                An `input` element without a `checked` attribute has an implicit "false" state. User Agents MUST ignore an `aria-checked` attribute
-                which conflicts with the native element's implicit checked state.
+                An `input` element in the `checkbox` or `radio` state without a `checked` attribute has an implicit "false" state. 
+                User Agents MUST ignore an `aria-checked` attribute which conflicts with the native element's implicit checked state.
               </td>
             </tr>
             <tr tabindex="-1" id="att-cite">

--- a/index.html
+++ b/index.html
@@ -3535,7 +3535,7 @@
             <tr tabindex="-1" id="att-checked">
               <th>`checked` (if present)</th>
               <td class="elements">
-                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checked` or `type=radio`
+                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
               </td>
               <td class="aria">
                 <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="true"

--- a/index.html
+++ b/index.html
@@ -3552,7 +3552,7 @@
             <tr tabindex="-1" id="att-checked-absent">
               <th>`checked` (if absent)</th>
               <td class="elements">
-                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checked` or `type=radio`
+                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
               </td>
               <td class="aria">
                 <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a> (state)="false"


### PR DESCRIPTION
HTML defines what inputs allow the checked attribute, but looking at `checked` mapping tables, someone might not realize this without following the link to the HTML spec that clarifies.  So this PR just clarifies that this mapping is for the input in the radio or checkbox state.

This is an editorial update, as there are no normative changes or implementation changes that need to be made.

closes #461


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/462.html" title="Last updated on Feb 28, 2023, 6:17 PM UTC (82d1404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/462/0323bc1...82d1404.html" title="Last updated on Feb 28, 2023, 6:17 PM UTC (82d1404)">Diff</a>