### PR TITLE
Addition: update and add missing attributes from HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -3467,7 +3467,7 @@
               <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-autocomplete-form">
-              <th>`autocomplete` "on|off"</th>
+              <th>`autocomplete`</th>
               <td class="elements">
                 <a data-cite="html/forms.html#attr-form-autocomplete">`form`</a>
               </td>
@@ -3576,7 +3576,7 @@
                 <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
               </td>
               <td class="aria">
-                <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="true"
+                <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a>="true"
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia">Property: `Toggle.ToggleState: On (1)`</td>
@@ -3593,7 +3593,7 @@
                 <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
               </td>
               <td class="aria">
-                <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a> (state)="false"
+                <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a>="false"
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia">Property: `Toggle.ToggleState: Off (0)`</td>
@@ -3890,6 +3890,30 @@
               <td class="ax"><div class="general">Not mapped</div></td>
               <td class="comments"></td>
             </tr>
+            <tr tabindex="-1" id="att-dir-bdo">
+              <th>`dir`</th>
+              <td class="elements">
+                <a data-cite="HTML">`bdo`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2">
+                <div class="general">
+                  Exposed as "writing-mode" text attribute on the text container.
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  Exposed by `TextFlowDirections` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="general">
+                  Exposed as "writing-mode" text attribute on the text container.
+                </div>
+              </td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
             <tr tabindex="-1" id="att-dirname">
               <th>`dirname`</th>
               <td class="elements">
@@ -3907,7 +3931,6 @@
               <th>`disabled`</th>
               <td class="elements">
                 <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`button`</a>;
-                <a data-cite="html/form-elements.html#attr-fieldset-disabled">`fieldset`</a>;
                 <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`input`</a>;
                 <a data-cite="html/form-elements.html#attr-optgroup-disabled">`optgroup`</a>;
                 <a data-cite="html/form-elements.html#attr-option-disabled">`option`</a>;
@@ -3921,8 +3944,38 @@
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="comments">
-                If the element includes both the `disabled` attribute and the `aria-disabled` attribute with a valid value, User Agents MUST expose only the `disabled` attribute value.
+                If the element has both the `disabled` attribute and the `aria-disabled` attribute with a valid value, 
+                User Agents MUST expose only the `disabled` attribute value.
               </td>
+            </tr>
+            <tr tabindex="-1" id="att-disabled-fieldset">
+              <th>`disabled`</th>
+              <td class="elements">
+                <a data-cite="html/form-elements.html#attr-fieldset-disabled">`fieldset`</a>
+              </td>
+              <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a></td>
+              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
+              <td class="comments">
+                <p>Form controls within a valid [^legend^] child element of a `fieldset` with a `disabled` attribute 
+                  do not become disabled.</p>
+                <p>If the element has both the `disabled` attribute and the `aria-disabled` attribute with a valid value, 
+                  User Agents MUST expose only the `disabled` attribute value.</p>
+              </td>
+            </tr>
+            <tr tabindex="-1" id="att-disabled-link">
+              <th>`disabled`</th>
+              <td class="elements">
+                <a data-cite="HTML">`link`</a>
+              </td>
+              <td class="aria">Not mapped</td>
+              <td class="ia2">Not mapped</td>
+              <td class="uia">Not mapped</td>
+              <td class="atk">Not mapped</td>
+              <td class="ax">Not mapped</td>
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="att-download">
               <th>`download`</th>
@@ -3960,6 +4013,33 @@
               <th>`enctype`</th>
               <td class="elements">
                 <a data-cite="html/form-control-infrastructure.html#attr-fs-enctype">`form`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr>
+            <tr tabindex="-1" id="att-enterkeyhint">
+              <th>`enterkeyhint`</th>
+              <td class="elements">
+                <a data-cite="html/interaction.html#attr-enterkeyhint">HTML elements</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments">Modifies the action label (or icon) to present for the 
+                <kbd>enter</kbd> key on virtual keyboards.</td>
+            </tr>
+            <tr tabindex="-1" id="att-fetchpriority">
+              <th>`fetchpriority`</th>
+              <td class="elements">
+                <a data-cite="html/embedded-content.html#attr-img-fetchpriority">`img`</a>;
+                <a data-cite="html/semantics.html#attr-link-fetchpriority">`link`</a>;
+                <a data-cite="html/scripting.html#attr-script-fetchpriority">`script`</a>
               </td>
               <td class="aria"><div class="general">Not mapped</div></td>
               <td class="ia2"><div class="general">Not mapped</div></td>


### PR DESCRIPTION
related to #400 

none of the updated or added attributes require implementation updates as updates either provide clarifications that reflect current implementations, or the attributes are not mapped.

creates separate table mappings for:
- bdo[dir]
- fieldset[disabled]

adds:
- link[disabled]
- [enterkeyhint]
- img, link, script[fetchpriority]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/469.html" title="Last updated on Apr 13, 2023, 10:56 PM UTC (60e01e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/469/7796f2e...60e01e7.html" title="Last updated on Apr 13, 2023, 10:56 PM UTC (60e01e7)">Diff</a>