### PR TITLE
Remove redundant datetime-local entry in mapping table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1449,7 +1449,8 @@
                 </td>
                 <td class="uia">
                   <div class="general">
-                    Depends on UI design of implementation. The UI in Windows 10 Edge, for example, is a composite of multiple spinners.
+                    Depends on UI design of implementation. 
+                    The UI in Windows 10 Edge, for example, is a composite of multiple spinners.
                   </div>
                 </td>
                 <td class="atk">
@@ -1471,38 +1472,41 @@
                 <!-- <td class="naming"></td> -->
                 <td class="comments"></td>
             </tr>
-            <tr tabindex="-1" id="el-input-dateandtime">
-                <th><a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the <a href="https://www.w3.org/TR/html/sec-forms.html#local-date-and-time-state-typedatetimelocal">Local Date and Time</a> state)</span></th>
-                <td class="aria">No corresponding role</td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role:</span> <code>IA2_ROLE_DATE_EDITOR</code>
-                  </div>
-                </td>
-                <td class="uia">
-                    <div class="general">
-                        Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
-                    </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span>
-                    <code>ATK_ROLE_CALENDAR</code>
-                  </div>
-                </td>
-                <td class="ax">
-                    <div class="role">
-                        <span class="type">AXRole:</span> `AXTextField`
-                    </div>
-                    <div class="subrole">
-                        <span class="type">AXSubrole:</span> `(nil)`
-                    </div>
-                    <div class="roledesc">
-                        <span class="type">AXRoleDescription:</span> <code>"text field"</code>
-                    </div>
-                </td>
-                <!-- <td class="naming"></td> -->
-                <td class="comments"></td>
+            <tr tabindex="-1" id="el-input-datetime-local">
+              <th>
+                <a data-cite="html">`input`</a>
+                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+                <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">Local Date and Time</a> state)</span>
+              </th>
+              <td class="aria">No corresponding role</td>
+              <td class="ia2">
+                <div class="role">
+                  <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
+                </div>
+              </td>
+              <td class="uia">
+                <div class="general">
+                  Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
+                </div>
+              </td>
+              <td class="atk">
+                <div class="role">
+                  <span class="type">Role:</span> `ATK_ROLE_CALENDAR`
+                </div>
+              </td>
+              <td class="ax">
+                <div class="role">
+                  <span class="type">AXRole:</span> `AXTextField`
+                </div>
+                <div class="subrole">
+                  <span class="type">AXSubrole:</span> `(nil)`
+                </div>
+                <div class="roledesc">
+                  <span class="type">AXRoleDescription:</span> `"text field"`
+                </div>
+              </td>
+              <!-- <td class="naming"></td> -->
+              <td class="comments"></td>
             </tr>
             <tr tabindex="-1" id="el-input-email">
               <th>
@@ -1606,42 +1610,6 @@
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-datetime-local">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
-                  <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">Local Date and Time</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CALENDAR`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXTextField`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"text field"`
-                </div>
-              </td>
               <!-- <td class="naming"></td> -->
               <td class="comments"></td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -1449,8 +1449,7 @@
                 </td>
                 <td class="uia">
                   <div class="general">
-                    Depends on UI design of implementation. 
-                    The UI in Windows 10 Edge, for example, is a composite of multiple spinners.
+                    Depends on UI design of implementation. The UI in Windows 10 Edge, for example, is a composite of multiple spinners.
                   </div>
                 </td>
                 <td class="atk">


### PR DESCRIPTION
closes #466

removes Local date time entry as it was duplicate to the existing datetime-local entry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/470.html" title="Last updated on May 3, 2023, 2:56 PM UTC (bc4df5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/470/04753c9...bc4df5f.html" title="Last updated on May 3, 2023, 2:56 PM UTC (bc4df5f)">Diff</a>