### PR TITLE
editorial: clarify naming for type=submit and reset buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -5922,12 +5922,10 @@
           </li>
           <li>Otherwise use the `value` attribute.</li>
           <li>
-            For `input type=submit`: If steps 1 to 2 do not yield a usable text string, the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is a localized string of the word &quot;submit&quot;.
+            For `input type=submit` and `type=reset`: if the prior steps do not yield a usable text string, and the `value` attribute is unspecified use the 
+            <a href="https://infra.spec.whatwg.org/#implementation-defined">implementation defined</a> string respective to the input type.
           </li>
-          <li>
-            For `input type=reset`: If steps 1 to 2 do not yield a usable text string, the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is a localized string of the word &quot;reset&quot;.
-          </li>
-          <li>Otherwise use `title` attribute.</li>
+          <li>Otherwise, if the control still has no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> use `title` attribute.</li>
           <li>
             If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
           </li>


### PR DESCRIPTION
closes #471
This PR does not require any implementation changes.  

in resolving #357, I failed to update the text that says "if steps 1 to 2..." - as the inclusion of label added a 3rd step. Looking at this further though, it seemed this could be clarified a bit more as the previous steps made it seem like if `value=""` was used, that the localized text strings of submit or reset should be used.  but that's not how this shakes out in reality, where if a value attribute is used, even if it's value is the empty string, it will become the control's accessible name.  

so the revised text is an attempt to make that clear, and purposefully removes saying to use the localized text string of submit or reset, since those can vary per browser.  Rather, I refer to these now as HTML does by saying the "implementation defined string".

The title attribute step was update to reference the fact that someone _could_ do `<input type=submit value>` which would mean the button had no accName, so if that's the case, then `title` should be used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/472.html" title="Last updated on May 3, 2023, 3:07 PM UTC (d156b7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/472/31361e8...d156b7a.html" title="Last updated on May 3, 2023, 3:07 PM UTC (d156b7a)">Diff</a>