### PR TITLE
Correction: map i element to emphasis

### DIFF
--- a/index.html
+++ b/index.html
@@ -1273,7 +1273,7 @@
                 <a data-cite="HTML">`i`</a>
               </th>
               <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+                <a class="core-mapping" href="#role-map-emphasis">`emphasis`</a> role
               </td>
               <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
               <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>


### PR DESCRIPTION
Closes #475

`i` should have also mapped to emphasis, similarly to how both `b` and `strong` map to `role=strong`.


## Implementation

* WPT tests: https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/39
* Implementations (link to issue or when done, link to commit):
   * WebKit: [ISSUE]()
   * Gecko: [ISSUE]()
   * Blink: [ISSUE]()


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/477.html" title="Last updated on May 9, 2023, 10:45 AM UTC (11e67e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/477/c9f494b...11e67e9.html" title="Last updated on May 9, 2023, 10:45 AM UTC (11e67e9)">Diff</a>