### PR TITLE
Clarify accName for input type=image

### DIFF
--- a/index.html
+++ b/index.html
@@ -6175,12 +6175,14 @@
           <li>
             Otherwise use the associated `label` element(s) <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>(s) - if more than one `label` is associated; concatenate by DOM order, delimited by spaces.
           </li>
-          <li>Otherwise use `alt` attribute.</li>
-          <!-- NOTE: use of valid attribute is invalid on input type=image, but it DOES contribute to the name if used -->
+          <li>Otherwise use `alt` attribute if present and its value is not the empty string.</li>
+          <!-- NOTE: use of value attribute is invalid on input type=image, but it DOES contribute to the name if used -->
           <!-- <li>Otherwise use `value` attribute.</li> -->
-          <li>Otherwise use `title` attribute.</li>
+          <li>Otherwise use `title` attribute if present and its value is not the empty string.</li>
           <li>
-            Otherwise if the previous steps do not yield a usable text string, the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is a localized string of the word &quot;Submit Query&quot;.
+            Otherwise if the previous steps do not yield a usable text string, use the 
+            <a href="https://infra.spec.whatwg.org/#implementation-defined">implementation defined</a> string respective to the input type (an `input` in the `image` state
+            represents a <a data-cite="html/forms.html#concept-submit-button">submit button</a>). For instance, a localized string of the word "submit" or the words &quot;Submit Query&quot;.
           </li>
           <li>
             If none of the above yield a usable text string there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.


### PR DESCRIPTION
adds clarifying language for the alt and title steps.  

updates the localized text string step to better match the updated input type=button/reset/submit, and note the fact that this element is considered a 'submit button' - linking to that portion of the HTML spec and noting that different browsers may provide a different default string (e.g., chrome does 'submit' while firefox does 'submit query')

Closes #414


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/497.html" title="Last updated on Jul 25, 2023, 1:45 PM UTC (075f7c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/497/551a9e9...075f7c4.html" title="Last updated on Jul 25, 2023, 1:45 PM UTC (075f7c4)">Diff</a>