### PR TITLE
Remove tables and details/summary in favor of unique headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       edDraftURI:           "https://w3c.github.io/html-aam/",
       // lcEnd:  "2010-08-06",
 
-      maxTocLevel: 2,
+      maxTocLevel: 3,
 
       // editors
       editors:  [

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <script src="common/script/resolveReferences.js" class="remove"></script>
   <script src="common/script/utility.js" class="remove"></script>
   <script src="common/biblio.js" class="remove" defer="defer"></script>
-  <script src="common/script/mapping-tables.js"></script>
 
   <link href="common/css/mapping-tables.css" rel="stylesheet" type="text/css"/>
   <link href="common/css/common.css" rel="stylesheet" type="text/css"/>
@@ -75,36 +74,11 @@
         "REC": "https://www.w3.org/TR/accname/"
       },
       xref: ["HTML", "core-aam", "accname", "wai-aria", "dom", "infra"],
-      preProcess: [ linkCrossReferences, mappingTables ],
+      preProcess: [ linkCrossReferences ],
       postProcess: [ fixContributors ],
       a11y: false
     };
   </script>
-  <script>
-    var mappingTableLabels = {
-      viewByTable: "View as a single table",
-      expand: "Expand all",
-      collapse: "Collapse all",
-      showHideCols: "Show/Hide Columns:",
-      showActionText: "Show",
-      hideActionText: "Hide",
-      showToolTipText: "Show column",
-      hideToolTipText: "Hide column",
-
-      // map where keys are @id of associated mapping table:
-      viewByLabels: {
-        "element-mapping-table": "View by element",
-        "attribute-mapping-table": "View by state/property"
-      }
-    }
-  </script>
-
-<!--   <style>
-    .table-container {
-      max-width: 100%;
-      overflow: auto;
-    }
-  </style> -->
 </head>
 <body>
   <section id="abstract">
@@ -237,1733 +211,3895 @@
           </ul>
         </li>
       </ul>
-      <div class="table-container">
-        <table class="map-table elements" id="element-mapping-table">
-          <caption>Mappings of HTML elements to platform <a class="termref">accessibility APIs</a>: ARIA, MSAA + UIA Express, MSAA + IAccessible2, UIA, ATK, and AX</caption>
-          <thead>
-            <tr>
-              <th>Element</th>
-              <th>[[wai-aria-1.2]]</th>
-              <th>Computed Role</th> <!-- need to link this to a definition of the term? -->
-              <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
-              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
-              <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
-              <th>Comments</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr tabindex="-1" id="el-a">
-              <th>
-                <a data-cite="HTML">`a`</a>
-                <span class="el-context">(represents a <a data-cite="html">hyperlink</a>)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-link">`link`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-a-no-href">
-              <th>
-                <a data-cite="HTML">`a`</a>
-                <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-abbr">
-              <th><a data-cite="HTML">`abbr`</a></th>
-              <td class="aria">
-                No corresponding role
-              </td>
-              <td class="role-computed"><div class="general">html-abbr</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span>
-                  "abbr" attribute on the containing <a href="#el-td">`td`</a> if a single child, text content used as a value
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span>
-                  "abbr" attribute on the containing <a href="#el-td">`td`</a> if a single child, text content used as a value
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-address">
-              <th><a data-cite="HTML">`address`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-group">`group`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-area">
-              <th>
-                <a data-cite="HTML">`area`</a>
-                <span class="el-context">(represents a <a data-cite="HTML">hyperlink</a>)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-link">`link`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-area-no-href">
-              <th>
-                <a data-cite="HTML">`area`</a>
-                <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-article">
-              <th>
-                <a data-cite="HTML">`article`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-article">`article`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-aside-ancestorbodymain">
-              <th>
-                <a data-cite="HTML">`aside`</a> (scoped to the `body` or `main` element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-aside">
-              <th>
-                <a data-cite="HTML">`aside`</a>
-                (scoped to a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role if the <a>`aside`</a> element has an <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
-                Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-audio">
-              <th>
-                <a data-cite="HTML">`audio`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-audio</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"audio"`
-                </div>
-                <div class="general">
-                  <b>Note:</b> If the <a data-cite="html/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the <a data-cite="HTML">`audio`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
-                </div>
-                <div class="general">
-                  Text objects associated with loading or error messages, and any UI control not currently displayed, MAY be present in the <a class="termref">accessibility tree</a> and marked as hidden or off-screen.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role: </span> `ATK_ROLE_AUDIO`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXAudio`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"audio playback"`
-                </div>
-                <div class="general">
-                  <b>Note:</b> If the <a data-cite="html/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-autonomous-custom-element">
-              <th>
-                <a data-cite="HTML">autonomous custom element</a>
-              </th>
-              <td class="aria">If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-b">
-              <th>
-                <a data-cite="HTML">`b`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">
-                Exposed by platform specific bold font weight text styles.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-base">
-              <th>
-                <a data-cite="HTML">`base`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-bdi">
-              <th>
-                <a data-cite="HTML">`bdi`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                IA2/ATK: May affect on "writing-mode" text attribute on its text container.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-bdo">
-              <th>
-                <a data-cite="HTML">`bdo`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                IA2/ATK: Exposed as "writing-mode" text attribute on its text container.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-blockquote">
-              <th>
-                <a data-cite="HTML">`blockquote`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-blockquote">`blockquote`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-body">
-              <th>
-                <a data-cite="HTML">`body`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-br">
-              <th><a data-cite="HTML">`br`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">May be exposed as '\n' character by the platform interface.</td>
-            </tr>
-            <tr tabindex="-1" id="el-button">
-              <th>
-                <a data-cite="HTML">`button`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-button">`button`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                A `button`'s mapping will change if the
-                <a class="core-mapping" href="#role-map-button-pressed">`aria-pressed`</a> or
-                <a class="core-mapping" href="#role-map-button-haspopup">`aria-haspopup`</a> attributes are specified.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-canvas">
-              <th>
-                <a data-cite="HTML">`canvas`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-canvas</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_GRAPHIC`; `IA2_ROLE_CANVAS`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Image`
-                </div>
-                <div class="general">
-                  Descendants of the `canvas` element are mapped separately.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CANVAS`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `""`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-caption">
-              <th>
-                <a data-cite="HTML">`caption`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-caption">`caption`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `IA2_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="relations">
-                  <span class="type">Other properties:</span> The `LabeledBy` property for the parent <a href="#el-table">`table`</a> element points to the 
-                  UIA element for the `caption` element.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">If a descendant of a `table`, the first instance of a `caption` element will provide the `table` its accessible name.</td>
-            </tr>
-            <tr tabindex="-1" id="el-cite">
-              <th>
-                <a data-cite="HTML">`cite`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-cite</div></td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. Styles used are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Styles used are mapped into text attributes on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-code">
-              <th>
-                <a data-cite="HTML">`code`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-code">`code`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-col">
-              <th>
-                <a data-cite="HTML">`col`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-colgroup">
-              <th>
-                <a data-cite="HTML">`colgroup`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  <div class="ctrltype">
-                    <span class="type">Control Type:</span> `Group`
-                  </div>
-                  <div class="ctrltype">
-                    <span class="type">Localized Control Type:</span> `"colgroup"`
-                  </div>
-                </div>
-              </td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-data">
-              <th>
-                <a data-cite="HTML">`data`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-datalist">
-              <th>
-                <a data-cite="HTML">`datalist`</a>
-                (represents pre-defined options for `input` element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-listbox">`listbox`</a> role, with the <a class="core-mapping" href="#ariaMultiselectableFalse">`aria-multiselectable`</a> property set to "true" if the `datalist`'s selection model allows multiple `option` elements to be selected at a time, and "false" otherwise
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                If `datalist` is not linked to a proper `input` element, then `datalist` element is not mapped to accessibility APIs.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-dd">
-              <th>
-                <a data-cite="HTML">`dd`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-definition">`definition`</a> role
-              </td>
-              <td class="role-computed">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="note">
-                  Editorial Note: This value may change upon resolution of <a href="https://github.com/w3c/aria/issues/1662">ARIA #1662</a>.
-                </div>
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-del">
-              <th>
-                <a data-cite="HTML">`del`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-deletion">`deletion`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-details">
-              <th>
-                <a data-cite="HTML">`details`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`group`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type: `"details"`</span>
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype">
-                  <span class="type">Relations: `"ATK_RELATION_DETAILS_FOR"`</span>
-                </div>
-              </td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-dfn">
-              <th>
-                <a data-cite="HTML">`dfn`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-term">`term`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-dialog">
-              <th>
-                <a data-cite="HTML">`dialog`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-dialog">`dialog`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                See also the `dialog` element's <a href="#att-open-dialog">`open`</a> attribute.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-div">
-              <th>
-                <a data-cite="HTML">`div`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-dl">
-              <th>
-                <a data-cite="HTML">`dl`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed">
-                <div class="general">list</div>
-                <div class="note">
-                  Editorial Note: This value may change upon resolution of <a href="https://github.com/w3c/aria/issues/1662">ARIA #1662</a>.
-                </div>
-              </td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_LIST`
-                </div>
-                <div class="states">
-                  <span class="type">States:</span> `STATE_SYSTEM_READONLY`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `List`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_DESCRIPTION_LIST`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXList`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXDefinitionList`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"definition list"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-dt">
-              <th>
-                <a data-cite="HTML">`dt`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-term">`term`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-em">
-              <th>
-                <a data-cite="HTML">`em`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-emphasis">`emphasis`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-embed">
-              <th>
-                <a data-cite="HTML">`embed`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-embed</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_CLIENT`; `IA2_ROLE_EMBEDDED_OBJECT`
-                </div>
-                <div class="states">
-                  <span class="type">States:</span> `STATE_SYSTEM_UNAVAILABLE` for windowless plugin
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Pane`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_EMBEDDED`
-                </div>
-              </td>
-              <td class="ax">Depends on format of data file</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-fieldset">
-              <th>
-                <a data-cite="HTML">`fieldset`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-group">`group`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</span>
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXFieldset`
-                </div>
-                <div class="roledesc">
-                  <div class="role-namefrom">
-                    <strong>AXDescription:</strong> value from child <a href="#el-legend">`legend`</a> subtree
-                  </div>
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-figcaption">
-              <th>
-                <a data-cite="HTML">`figcaption`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">caption</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_CAPTION`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CAPTION`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-figure">
-              <th>
-                <a data-cite="HTML">`figure`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-figure">`figure`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
-                </div>
-              </td>
-              <td class="uia">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping
-                </div>
-                <div class="general">
-                  Accessible name derived from `figcaption` according to the <a href="#figure-element-accessible-name-computation">`figure` Element Accessible Name Computation</a>
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> Use WAI-ARIA mapping</div>
-                <div class="name">
-                  <span class="type">Name:</span> related <a href="#el-figcaption">`figcaption`</a> content
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> Use WAI-ARIA mapping
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-footer-ancestorbody">
-              <th>
-                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`body`</a> element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-contentinfo">`contentinfo`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-footer">
-              <th>
-                <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element,
-                a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-                <div class="note">
-                  Editorial Note: This value may change upon resolution of <a href="https://github.com/w3c/aria/issues/1915">ARIA #1915</a>.
-                </div>
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"footer"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_FOOTER`
-                </div>
-              </td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                If a `footer` is not scoped to the `body` element,
-                do not expose the element as a `contentinfo` landmark.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-form">
-              <th>
-                <a data-cite="HTML">`form`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-form">`form`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div>If a `form` has no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>:</div>
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_FORM`
-                </div>
-              </td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                If a <a class="core-mapping" href="#role-map-form-nameless">`form` has no accessible name</a>,
-                do not expose the element as a landmark.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-form-associated-custom-element">
-              <th>
-                <a data-cite="html/custom-elements.html#custom-elements-face-example">form-associated custom element</a>
-              </th>
-              <td class="aria">If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-h1-h6">
-              <th>
-                <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`, `h2`, `h3`, `h4`, `h5`, and `h6`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-heading">`heading`</a> role, with the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property set to the number in the element's tag name.
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-head">
-              <th><a data-cite="html">`head`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-header-ancestorbody">
-              <th>
-                <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`body`</a> element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-banner">`banner`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-header">
-              <th>
-                <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`main`</a> element, or a <a data-cite="html/dom.html#sectioning-content">sectioning content</a> element)
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-                <div class="note">
-                  Editorial Note: This value may change upon resolution of <a href="https://github.com/w3c/aria/issues/1915">ARIA #1915</a>.
-                </div>
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"header"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_HEADER`
-                </div>
-              </td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                If a `header` is not scoped to the `body` element,
-                do not expose the element as a `banner` landmark.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-hgroup">
-              <th>
-                <a data-cite="HTML">`hgroup`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-group">`group`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                If an `hgroup` contains multiple heading elements, then the heading element with the highest priority level 
-                MAY be treated as the sole heading of the `hgroup`. All other heading elements MAY instead be exposed as if they
-                were <a href="#el-p">`p`</a> elements. See <a class="core-mapping" href="#role-map-paragraph">`paragraph` role on Core AAM</a>.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-hr">
-              <th>
-                <a data-cite="HTML">`hr`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-separator">`separator`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-html">
-              <th>
-                <a data-cite="HTML">`html`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-document">`document`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-i">
-              <th>
-                <a data-cite="HTML">`i`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                Exposed by platform specific italic text styles.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-iframe">
-              <th>
-                <a data-cite="HTML">`iframe`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-iframe</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_INTERNAL_FRAME`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Pane`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_INTERNAL_FRAME`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXWebArea`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"html content"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-img">
-              <th>
-                <a data-cite="HTML">`img`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-img">`img`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-img-empty-alt">
-              <th>
-                <a data-cite="html">`img`</a>
-                <span class="el-context">(<a data-cite="html/embedded-content.html#attr-img-alt">`alt`</a>
+<h4 id=el-a>`a`<span class="el-context">(represents a hyperlink)</span></h4>
+<table aria-labelledby=el-a>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`a`</a>
+        <span class="el-context">(represents a <a data-cite="html">hyperlink</a>)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-link">`link`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-a-no-href>`a`<span class="el-context">(no `href` attribute)</span></h4>
+<table aria-labelledby=el-a-no-href>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`a`</a>
+        <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-abbr>`abbr`</h4>
+<table aria-labelledby=el-abbr>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`abbr`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span>
+          "abbr" attribute on the containing <a href="#el-td">`td`</a> if a single child, text content used as a value
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Text`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_STATIC`
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span>
+          "abbr" attribute on the containing <a href="#el-td">`td`</a> if a single child, text content used as a value
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-address>`address`</h4>
+<table aria-labelledby=el-address>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`address`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-group">`group`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-area>`area`<span class="el-context">(represents a hyperlink)</span></h4>
+<table aria-labelledby=el-area>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`area`</a>
+        <span class="el-context">(represents a <a data-cite="HTML">hyperlink</a>)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-link">`link`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-area-no-href>`area`<span class="el-context">(no `href` attribute)</span></h4>
+<table aria-labelledby=el-area-no-href>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`area`</a>
+        <span class="el-context">(no <a data-cite="html/links.html#attr-hyperlink-href">`href`</a> attribute)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-article>`article`</h4>
+<table aria-labelledby=el-article>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`article`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-article">`article`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-aside-ancestorbodymain>`aside` (scoped to the `body` or `main` element)</h4>
+<table aria-labelledby=el-aside-ancestorbodymain>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`aside`</a> (scoped to the `body` or `main` element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-aside>`aside`(scoped to a sectioning content element)</h4>
+<table aria-labelledby=el-aside>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`aside`</a>
+        (scoped to a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-complementary">`complementary`</a> role if the <a>`aside`</a> element has an <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
+        Otherwise, <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-audio>`audio`</h4>
+<table aria-labelledby=el-audio>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`audio`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Group`
+        </div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"audio"`
+        </div>
+        <div class="general">
+          <b>Note:</b> If the <a data-cite="html/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the <a data-cite="HTML">`audio`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
+        </div>
+        <div class="general">
+          Text objects associated with loading or error messages, and any UI control not currently displayed, MAY be present in the <a class="termref">accessibility tree</a> and marked as hidden or off-screen.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role: </span> `ATK_ROLE_AUDIO`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXAudio`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"audio playback"`
+        </div>
+        <div class="general">
+          <b>Note:</b> If the <a data-cite="html/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-autonomous-custom-element>autonomous custom element</h4>
+<table aria-labelledby=el-autonomous-custom-element>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">autonomous custom element</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-b>`b`</h4>
+<table aria-labelledby=el-b>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`b`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Exposed by platform specific bold font weight text styles.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-base>`base`</h4>
+<table aria-labelledby=el-base>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`base`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-bdi>`bdi`</h4>
+<table aria-labelledby=el-bdi>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`bdi`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        IA2/ATK: May affect on "writing-mode" text attribute on its text container.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-bdo>`bdo`</h4>
+<table aria-labelledby=el-bdo>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`bdo`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        IA2/ATK: Exposed as "writing-mode" text attribute on its text container.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-blockquote>`blockquote`</h4>
+<table aria-labelledby=el-blockquote>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`blockquote`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-blockquote">`blockquote`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-body>`body`</h4>
+<table aria-labelledby=el-body>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`body`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-br>`br`</h4>
+<table aria-labelledby=el-br>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`br`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        May be exposed as '\n' character by the platform interface.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-button>`button`</h4>
+<table aria-labelledby=el-button>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`button`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-button">`button`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        A `button`'s mapping will change if the
+        <a class="core-mapping" href="#role-map-button-pressed">`aria-pressed`</a> or
+        <a class="core-mapping" href="#role-map-button-haspopup">`aria-haspopup`</a> attributes are specified.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-canvas>`canvas`</h4>
+<table aria-labelledby=el-canvas>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`canvas`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Roles:</span> `ROLE_SYSTEM_GRAPHIC`; `IA2_ROLE_CANVAS`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Image`
+        </div>
+        <div class="general">
+          Descendants of the `canvas` element are mapped separately.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_CANVAS`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `""`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-caption>`caption`</h4>
+<table aria-labelledby=el-caption>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`caption`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-caption">`caption`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `IA2_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Other properties:</span> The `LabeledBy` property for the parent <a href="#el-table">`table`</a> element points to the
+          UIA element for the `caption` element.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `ATK_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `ATK_RELATION_LABEL_FOR` with parent <a href="#el-table">`table`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If a descendant of a `table`, the first instance of a `caption` element will provide the `table` its accessible name.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-cite>`cite`</h4>
+<table aria-labelledby=el-cite>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`cite`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          No accessible object. Styles used are mapped into text attributes on its text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          No accessible object. Styles used are exposed by UIA text attributes of the `TextRange` Control Pattern implemented on a parent accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          No accessible object. Styles used are mapped into text attributes on its text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-code>`code`</h4>
+<table aria-labelledby=el-code>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`code`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-code">`code`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-col>`col`</h4>
+<table aria-labelledby=el-col>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`col`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-colgroup>`colgroup`</h4>
+<table aria-labelledby=el-colgroup>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`colgroup`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          <div class="ctrltype">
+            <span class="type">Control Type:</span> `Group`
+          </div>
+          <div class="ctrltype">
+            <span class="type">Localized Control Type:</span> `"colgroup"`
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-data>`data`</h4>
+<table aria-labelledby=el-data>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`data`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-datalist>`datalist`(represents pre-defined options for `input` element)</h4>
+<table aria-labelledby=el-datalist>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`datalist`</a>
+        (represents pre-defined options for `input` element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-listbox">`listbox`</a> role, with the <a class="core-mapping" href="#ariaMultiselectableFalse">`aria-multiselectable`</a> property set to "true" if the `datalist`'s selection model allows multiple `option` elements to be selected at a time, and "false" otherwise
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If `datalist` is not linked to a proper `input` element, then `datalist` element is not mapped to accessibility APIs.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-dd>`dd`</h4>
+<table aria-labelledby=el-dd>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`dd`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-definition">`definition`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-del>`del`</h4>
+<table aria-labelledby=el-del>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`del`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-deletion">`deletion`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-details>`details`</h4>
+<table aria-labelledby=el-details>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`details`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`group`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type: `"details"`</span>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="ctrltype">
+          <span class="type">Relations: `"ATK_RELATION_DETAILS_FOR"`</span>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-dfn>`dfn`</h4>
+<table aria-labelledby=el-dfn>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`dfn`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-term">`term`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-dialog>`dialog`</h4>
+<table aria-labelledby=el-dialog>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`dialog`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-dialog">`dialog`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        See also the `dialog` element's <a href="#att-open-dialog">`open`</a> attribute.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-div>`div`</h4>
+<table aria-labelledby=el-div>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`div`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-dl>`dl`</h4>
+<table aria-labelledby=el-dl>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`dl`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_LIST`
+        </div>
+        <div class="states">
+          <span class="type">States:</span> `STATE_SYSTEM_READONLY`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `List`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_DESCRIPTION_LIST`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXList`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXDefinitionList`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"definition list"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-dt>`dt`</h4>
+<table aria-labelledby=el-dt>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`dt`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-term">`term`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-em>`em`</h4>
+<table aria-labelledby=el-em>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`em`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-emphasis">`emphasis`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-embed>`embed`</h4>
+<table aria-labelledby=el-embed>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`embed`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Roles:</span> `ROLE_SYSTEM_CLIENT`; `IA2_ROLE_EMBEDDED_OBJECT`
+        </div>
+        <div class="states">
+          <span class="type">States:</span> `STATE_SYSTEM_UNAVAILABLE` for windowless plugin
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Pane`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_EMBEDDED`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Depends on format of data file
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-fieldset>`fieldset`</h4>
+<table aria-labelledby=el-fieldset>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`fieldset`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-group">`group`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> Use WAI-ARIA mapping
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="role"><span class="type">Role:</span> Use WAI-ARIA mapping</span>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> Use WAI-ARIA mapping
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> Use WAI-ARIA mapping
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXFieldset`
+        </div>
+        <div class="roledesc">
+          <div class="role-namefrom">
+            <strong>AXDescription:</strong> value from child <a href="#el-legend">`legend`</a> subtree
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-figcaption>`figcaption`</h4>
+<table aria-labelledby=el-figcaption>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`figcaption`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_CAPTION`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Text`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_CAPTION`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `ATK_RELATION_LABEL_FOR` with parent <a href="#el-figure">`figure`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-figure>`figure`</h4>
+<table aria-labelledby=el-figure>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`figure`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-figure">`figure`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> Use WAI-ARIA mapping
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> Use WAI-ARIA mapping
+        </div>
+        <div class="general">
+          Accessible name derived from `figcaption` according to the <a href="#figure-element-accessible-name-computation">`figure` Element Accessible Name Computation</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> Use WAI-ARIA mapping
+        </div>
+        <div class="name">
+          <span class="type">Name:</span> related <a href="#el-figcaption">`figcaption`</a> content
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-figcaption">`figcaption`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> Use WAI-ARIA mapping
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-footer-ancestorbody>`footer` (scoped to the `body` element)</h4>
+<table aria-labelledby=el-footer-ancestorbody>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`body`</a> element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-contentinfo">`contentinfo`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-footer>`footer` (scoped to the `main` element,a sectioning content element)</h4>
+<table aria-labelledby=el-footer>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`footer`</a> (scoped to the <a data-cite="HTML">`main`</a> element,
+        a <a data-cite="HTML/dom.html#sectioning-content">sectioning content</a> element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Group`
+        </div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"footer"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_FOOTER`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If a `footer` is not scoped to the `body` element,
+        do not expose the element as a `contentinfo` landmark.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-form>`form`</h4>
+<table aria-labelledby=el-form>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-form">`form`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div>If a `form` has no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>:</div>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_FORM`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If a <a class="core-mapping" href="#role-map-form-nameless">`form` has no accessible name</a>,
+        do not expose the element as a landmark.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-form-associated-custom-element>form-associated custom element</h4>
+<table aria-labelledby=el-form-associated-custom-element>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/custom-elements.html#custom-elements-face-example">form-associated custom element</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        If the author assigned a conforming ARIA role using the `role` attribute, map to that role. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-h1-h6>`h1`, `h2`, `h3`, `h4`, `h5`, and `h6`</h4>
+<table aria-labelledby=el-h1-h6>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1`, `h2`, `h3`, `h4`, `h5`, and `h6`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-heading">`heading`</a> role, with the <a class="core-mapping" href="#ariaLevel">`aria-level`</a> property set to the number in the element's tag name.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-head>`head`</h4>
+<table aria-labelledby=el-head>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`head`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-header-ancestorbody>`header` (scoped to the `body` element)</h4>
+<table aria-labelledby=el-header-ancestorbody>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`body`</a> element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-banner">`banner`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-header>`header` (scoped to the `main` element, or a sectioning content element)</h4>
+<table aria-labelledby=el-header>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`header`</a> (scoped to the <a data-cite="html">`main`</a> element, or a <a data-cite="html/dom.html#sectioning-content">sectioning content</a> element)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Group`
+        </div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"header"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_HEADER`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If a `header` is not scoped to the `body` element,
+        do not expose the element as a `banner` landmark.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-hgroup>`hgroup`</h4>
+<table aria-labelledby=el-hgroup>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`hgroup`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-group">`group`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If an `hgroup` contains multiple heading elements, then the heading element with the highest priority level
+        MAY be treated as the sole heading of the `hgroup`. All other heading elements MAY instead be exposed as if they
+        were <a href="#el-p">`p`</a> elements. See <a class="core-mapping" href="#role-map-paragraph">`paragraph` role on Core AAM</a>.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-hr>`hr`</h4>
+<table aria-labelledby=el-hr>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`hr`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-separator">`separator`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-html>`html`</h4>
+<table aria-labelledby=el-html>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`html`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-document">`document`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-i>`i`</h4>
+<table aria-labelledby=el-i>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`i`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Exposed by platform specific italic text styles.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-iframe>`iframe`</h4>
+<table aria-labelledby=el-iframe>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`iframe`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_INTERNAL_FRAME`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Pane`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_INTERNAL_FRAME`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXWebArea`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"html content"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-img>`img`</h4>
+<table aria-labelledby=el-img>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-img">`img`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-img-empty-alt>`img`<span class="el-context">(`alt`attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span></h4>
+<table aria-labelledby=el-img-empty-alt>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`img`</a>
+        <span class="el-context">(<a data-cite="html/embedded-content.html#attr-img-alt">`alt`</a>
                 attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span>
-              </th>
-              <td class="aria">
-                <div class="role">
-                  <a class="core-mapping" href="#role-map-presentation">`presentation`</a>
-                </div>
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-button">
-              <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <div class="role">
+          <a class="core-mapping" href="#role-map-presentation">`presentation`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-button>`input` <span class="el-context">(`type` attribute in the  Button state)</span></h4>
+<table aria-labelledby=el-input-button>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#button-state-(type=button)">Button</a> state)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-button">`button`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-checkbox">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-button">`button`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-checkbox>`input`<span class="el-context">(`type` attribute in the  Checkbox state)</span></h4>
+<table aria-labelledby=el-input-checkbox>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-checkbox">`checkbox`</a> role, with the
-                <a class="core-mapping" href="#ariaCheckedMixed">`aria-checked`</a> state set to "mixed" if the element's
-                <a data-cite="html/input.html#dom-input-indeterminate">`indeterminate` IDL attribute</a> is true, or "true" if the element's
-                <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-color">
-              <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-checkbox">`checkbox`</a> role, with the
+        <a class="core-mapping" href="#ariaCheckedMixed">`aria-checked`</a> state set to "mixed" if the element's
+        <a data-cite="html/input.html#dom-input-indeterminate">`indeterminate` IDL attribute</a> is true, or "true" if the element's
+        <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-color>`input` <span class="el-context">(`type` attribute in theColor state)</span></h4>
+<table aria-labelledby=el-input-color>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                 <a data-cite="html/input.html#color-state-(type=color)">Color</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-input-color</div></td>
-              <td class="ia2">
-                <div class="general">If implemented as a textbox:</div>
-                <div class="role"><span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`</div>
-                <div class="general">If implemented as a color picker:</div>
-                <div class="role"><span class="type">Roles:</span> `IA2_ROLE_COLOR_CHOOSER`</div>
-              </td>
-              <td class="uia">
-                <div class="general">If implemented as a textbox:</div>
-                <div class="ctrltype"><span class="type">Control Type:</span> `Edit`</div>
-                <div class="properties"><span class="type">Localized Control Type: </span> "edit"</div>
-                <div class="general">If implemented as a color picker:</div>
-                <div class="ctrltype"><span class="type">Control Type:</span> `button`</div>
-                <div class="properties"><span class="type">Localized Control Type: </span> "color picker"</div>
-                <!-- <div class="ctrlpattern"><span class="type">Control Pattern:</span> `Selection` for the container and `SelectionItem` for each color choice</div> -->
-              </td>
-              <td class="atk">
-                <div class="general">
-                  If implemented as a button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-button">`button`</a>.
-                </div>
-                <div class="general">
-                  If implemented as a textbox, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">If implemented as a textbox:</div>
-                <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
-                <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
-                <div class="roledesc"><span class="type">AXRoleDescription:</span> `"text field"`</div>
-                <div class="general">If implemented as a color picker:</div>
-                <div class="role"><span class="type">AXRole:</span> `AXColorWell`</div>
-                <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
-                <div class="roledesc"><span class="type">AXRoleDescription:</span> `"color well"`</div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                <div class="general">
-                  If implemented as a color picker, any UI controls presented for selecting a color are exposed in the <a class="termref">accessibility tree</a>, associated with the `input` element, and mapped as appropriate for the type of control (e.g. button or slider).
-                </div>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-input-date">
-              <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">If implemented as a textbox:</div>
+        <div class="role"><span class="type">Roles:</span> `ROLE_SYSTEM_TEXT`</div>
+        <div class="general">If implemented as a color picker:</div>
+        <div class="role"><span class="type">Roles:</span> `IA2_ROLE_COLOR_CHOOSER`</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">If implemented as a textbox:</div>
+        <div class="ctrltype"><span class="type">Control Type:</span> `Edit`</div>
+        <div class="properties"><span class="type">Localized Control Type: </span> "edit"</div>
+        <div class="general">If implemented as a color picker:</div>
+        <div class="ctrltype"><span class="type">Control Type:</span> `button`</div>
+        <div class="properties"><span class="type">Localized Control Type: </span> "color picker"</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          If implemented as a button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-button">`button`</a>.
+        </div>
+        <div class="general">
+          If implemented as a textbox, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">If implemented as a textbox:</div>
+        <div class="role"><span class="type">AXRole:</span> `AXTextField`</div>
+        <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
+        <div class="roledesc"><span class="type">AXRoleDescription:</span> `"text field"`</div>
+        <div class="general">If implemented as a color picker:</div>
+        <div class="role"><span class="type">AXRole:</span> `AXColorWell`</div>
+        <div class="subrole"><span class="type">AXSubrole:</span> `(nil)`</div>
+        <div class="roledesc"><span class="type">AXRoleDescription:</span> `"color well"`</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">
+          If implemented as a color picker, any UI controls presented for selecting a color are exposed in the <a class="termref">accessibility tree</a>, associated with the `input` element, and mapped as appropriate for the type of control (e.g. button or slider).
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-date>`input` <span class="el-context">(`type` attribute in theDate state)</span></h4>
+<table aria-labelledby=el-input-date>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                 <a data-cite="html/input.html#date-state-(type=date)">Date</a> state)</span>
-              </th>
-                <td class="aria">No corresponding role</td>
-                <td class="role-computed"><div class="general">html-input-date</div></td>
-                <td class="ia2">
-                  <div class="general">If implemented as a textbox:</div>
-                  <div class="role">
-                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`
-                  </div>
-                  <div class="objattrs">
-                    <span class="type">Object attributes:</span> `text-input-type:date`
-                  </div>
-                  <div class="general">If implemented as a date picker:</div>
-                  <div class="role">
-                    <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="general">
-                    Depends on UI design of implementation. The UI in Windows 10 Edge, for example, is a composite of multiple spinners.
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role: </span> `ATK_ROLE_CALENDAR`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXDateField`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"date field"`
-                  </div>
-                </td>
-                <!-- <td class="naming"></td> -->
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-datetime-local">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">If implemented as a textbox:</div>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:date`
+        </div>
+        <div class="general">If implemented as a date picker:</div>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Depends on UI design of implementation. The UI in Windows 10 Edge, for example, is a composite of multiple spinners.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role: </span> `ATK_ROLE_CALENDAR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXDateField`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"date field"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-datetime-local>`input`<span class="el-context">(`type` attribute in theLocal Date and Time state)</span></h4>
+<table aria-labelledby=el-input-datetime-local>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                 <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">Local Date and Time</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CALENDAR`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXTextField`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"text field"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-email">
-              <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_CALENDAR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXTextField`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"text field"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-email>`input` <span class="el-context">(`type` attribute in the  E-mail state with no suggestions source element)</span></h4>
+<table aria-labelledby=el-input-email>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#email-state-(type=email)">E-mail</a> state with no <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="objattrs"> <span class="type">Object attributes: </span> `text-input-type:email` </div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"email"`
-                </div>
-              </td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-file">
-              <th>
-                <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="objattrs"> <span class="type">Object attributes: </span> `text-input-type:email` </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"email"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-file>`input` <span class="el-context">(`type` attribute in the  File Upload state)</span></h4>
+<table aria-labelledby=el-input-file>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a> <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#file-upload-state-(type=file)">File Upload</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-input-file</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Implementation dependent. If represented by a container with a button a text label inside then:
-                </div>
-                <div class="role">
-                  <span class="type">Roles:</span> `IA2_ROLE_TEXT_FRAME`
-                </div>
-                <div class="children">
-                  <span class="type">Children:</span> `ROLE_SYSTEM_PUSHBUTTON` and `IA2_ROLE_LABEL` for a button and a text label elements.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Can be rendered as a single button control, or as a button control with a text input field.
-                </div>
-                <div class="general">Button control:</div>
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Button`
-                </div>
-                <div class="general">Text input field:</div>
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Edit`
-                </div>
-                <div class="property">
-                  <span class="type">Localized Control Type:</span> `"file"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                </div>
-                <div class="children">
-                  <span class="type">Children:</span>
-                  `ATK_ROLE_PUSH_BUTTON` when pressed `ATK_ROLE_FILE_CHOOSER` dialog shown
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXButton`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXFileUploadButton`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `file upload button`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-hidden">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Implementation dependent. If represented by a container with a button a text label inside then:
+        </div>
+        <div class="role">
+          <span class="type">Roles:</span> `IA2_ROLE_TEXT_FRAME`
+        </div>
+        <div class="children">
+          <span class="type">Children:</span> `ROLE_SYSTEM_PUSHBUTTON` and `IA2_ROLE_LABEL` for a button and a text label elements.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Can be rendered as a single button control, or as a button control with a text input field.
+        </div>
+        <div class="general">Button control:</div>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Button`
+        </div>
+        <div class="general">Text input field:</div>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Edit`
+        </div>
+        <div class="property">
+          <span class="type">Localized Control Type:</span> `"file"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_STATIC`
+        </div>
+        <div class="children">
+          <span class="type">Children:</span>
+          `ATK_ROLE_PUSH_BUTTON` when pressed `ATK_ROLE_FILE_CHOOSER` dialog shown
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXButton`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXFileUploadButton`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `file upload button`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-hidden>`input`<span class="el-context">(`type` attribute in the  Hidden state)</span></h4>
+<table aria-labelledby=el-input-hidden>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#hidden-state-(type=hidden)">Hidden</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-image">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-image>`input`<span class="el-context">(`type` attribute in the  Image Button state)</span></h4>
+<table aria-labelledby=el-input-image>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#image-button-state-(type=image)">Image Button</a> state)</span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-button">`button`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-month">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-button">`button`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-month>`input`<span class="el-context">(`type` attribute in the  Month state)</span></h4>
+<table aria-labelledby=el-input-month>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#month-state-(type=month)">Month</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-input-month</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_DATE_EDITOR`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXTextField`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"text field"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-number">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_DATE_EDITOR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXTextField`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"text field"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-number>`input`<span class="el-context">(`type` attribute in the  Number state)</span></h4>
+<table aria-labelledby=el-input-number>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#number-state-(type=number)">Number</a> state)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">
-                  If implemented as a spin button, use WAI-ARIA mapping for
-                  <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.
-                </div>
-                <div class="general">
-                  If implemented as a text input, use WAI-ARIA mapping for
-                  <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `text-input-type:number`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.</div>
-                <div class="general">If implemented as a text input:</div>
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Edit`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"number"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.
-                </div>
-                <div class="general">
-                  If implemented as a text input, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `text-input-type:number`
-                </div>
-              </td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-password">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          If implemented as a spin button, use WAI-ARIA mapping for
+          <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.
+        </div>
+        <div class="general">
+          If implemented as a text input, use WAI-ARIA mapping for
+          <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:number`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.</div>
+        <div class="general">If implemented as a text input:</div>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Edit`
+        </div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"number"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          If implemented as a spin button, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-spinbutton">`spinbutton`</a>.
+        </div>
+        <div class="general">
+          If implemented as a text input, use WAI-ARIA mapping for <a class="core-mapping" href="#role-map-textbox">`textbox`</a>.
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:number`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-password>`input`<span class="el-context">(`type` attribute in the  Password state)</span></h4>
+<table aria-labelledby=el-input-password>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#password-state-(type=password)">Password</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-input-password</div></td>
-              <td class="ia2">
-                <div class="role"><span class="type">Role:</span> `ROLE_SYSTEM_TEXT`</div>
-                <div class="states">
-                  <span class="type">States:</span> `STATE_SYSTEM_PROTECTED`; `IA2_STATE_SINGLE_LINE`; `STATE_SYSTEM_READONLY` if readonly, otherwise `IA2_STATE_EDITABLE`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Edit`
-                </div>
-                <div class="properties">
-                  <span class="type">Localized Control Type:</span> `"password"`
-                </div>
-                <div class="properties">
-                  <span class="type">Other properties: </span>Set `isPassword` to `true`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role"><span class="type">Role:</span> `ATK_ROLE_PASSWORD_TEXT`</div>
-                <div class="states">
-                  <span class="type">States:</span> `ATK_STATE_SINGLE_LINE`; `ATK_STATE_READ_ONLY` if readonly, otherwise `ATK_STATE_EDITABLE`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXTextField`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXSecureTextField`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"secure text field"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-radio">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role"><span class="type">Role:</span> `ROLE_SYSTEM_TEXT`</div>
+        <div class="states">
+          <span class="type">States:</span> `STATE_SYSTEM_PROTECTED`; `IA2_STATE_SINGLE_LINE`; `STATE_SYSTEM_READONLY` if readonly, otherwise `IA2_STATE_EDITABLE`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Edit`
+        </div>
+        <div class="properties">
+          <span class="type">Localized Control Type:</span> `"password"`
+        </div>
+        <div class="properties">
+          <span class="type">Other properties: </span>Set `isPassword` to `true`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role"><span class="type">Role:</span> `ATK_ROLE_PASSWORD_TEXT`</div>
+        <div class="states">
+          <span class="type">States:</span> `ATK_STATE_SINGLE_LINE`; `ATK_STATE_READ_ONLY` if readonly, otherwise `ATK_STATE_EDITABLE`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXTextField`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXSecureTextField`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"secure text field"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-radio>`input`<span class="el-context">(`type` attribute in the  Radio Button state)</span></h4>
+<table aria-labelledby=el-input-radio>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#radio-button-state-(type=radio)">Radio Button</a> state)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-radio">`radio`</a> role, with the
-                <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> state set to "true" if the element's
-                <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise.
-                With <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `type=radio input` elements within the
-                <a data-cite="html/input.html#radio-button-group">radio button group</a>
-                and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the elements position within the <a data-cite="html/input.html#radio-button-group">radio button group</a>.
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-range">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-radio">`radio`</a> role, with the
+        <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> state set to "true" if the element's
+        <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise.
+        With <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of `type=radio input` elements within the
+        <a data-cite="html/input.html#radio-button-group">radio button group</a>
+        and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a> value reflecting the elements position within the <a data-cite="html/input.html#radio-button-group">radio button group</a>.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-range>`input`<span class="el-context">(`type` attribute in the  Range state)</span></h4>
+<table aria-labelledby=el-input-range>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#range-state-(type=range)">Range</a> state)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-slider">`slider`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-reset">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-slider">`slider`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-reset>`input`<span class="el-context">(`type` attribute in the  Reset Button state)</span></h4>
+<table aria-labelledby=el-input-reset>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#reset-button-state-(type=reset)">Reset Button</a> state)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-button">`button`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-search">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-button">`button`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-search>`input`<span class="el-context">(`type` attribute in the  Search state with no suggestions source element)</span></h4>
+<table aria-labelledby=el-input-search>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Search</a> state with no <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-searchbox">`searchbox`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-submit">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-searchbox">`searchbox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-submit>`input`<span class="el-context">  (`type` attribute in the  Submit Button state)</span></h4>
+<table aria-labelledby=el-input-submit>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">
                   (<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#submit-button-state-(type=submit)">Submit Button</a> state)
                 </span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-button">`button`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-tel">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-button">`button`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-tel>`input`<span class="el-context">  (`type` attribute in the  Telephone state with no  suggestions source element)</span></h4>
+<table aria-labelledby=el-input-tel>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">
                   (<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#telephone-state-(type=tel)">Telephone</a> state with no
                   <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)
                 </span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="objattrs">
-                  <span class="type">Object attributes: </span> `text-input-type:telephone`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"telephone"`
-                </div>
-              </td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-text">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="objattrs">
+          <span class="type">Object attributes: </span> `text-input-type:telephone`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"telephone"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-text>`input`<span class="el-context">  (`type` attribute in the  Text state with no  suggestions source element)</span></h4>
+<table aria-labelledby=el-input-text>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">
                   (<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Text</a> state with no
                   <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)
                 </span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">An `input` with a missing or invalid <a data-cite="html/input.html#attr-input-type">`type` attribute</a> 
-                defaults to the Text state.</td>
-            </tr>
-            <tr tabindex="-1" id="el-input-textetc-autocomplete">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-textetc-autocomplete>`input`<span class="el-context">  (`type` attribute in the  Text,  Search,  Telephone,  URL, or  E-mail states with a  suggestions source element)</span></h4>
+<table aria-labelledby=el-input-textetc-autocomplete>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">
                   (<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Text</a>,
                   <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">Search</a>,
@@ -1972,1171 +4108,2916 @@
                   <a data-cite="html/input.html#email-state-(type=email)">E-mail</a> states with a
                   <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)
                 </span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-combobox">`combobox`</a> role, with the
-                <a class="core-mapping" href="#ariaControls">`aria-controls`</a> property set to the same value as the
-                <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `text-input-type:<em>as per input type</em>`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="properties">
-                  <span class="type">Other properties:</span> `ControllerFor` points to the suggestions source element
-                </div>
-              </td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                See also <a href="#att-list">`list` attribute mappings</a>.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-input-time">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-combobox">`combobox`</a> role, with the
+        <a class="core-mapping" href="#ariaControls">`aria-controls`</a> property set to the same value as the
+        <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:<em>as per input type</em>`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="properties">
+          <span class="type">Other properties:</span> `ControllerFor` points to the suggestions source element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-time>`input`<span class="el-context">(`type` attribute in the  Time state)</span></h4>
+<table aria-labelledby=el-input-time>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#time-state-(type=time)">Time</a> state)</span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-input-time</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_SPINBUTTON` if implemented as a simple <a class="termref">widget</a>; `ROLE_SYSTEM_GROUPING` with child controls mapped as appropriate if implemented as a complex <a class="termref">widget</a>
-                </div>
-                 <div class="objattrs">
-                  <span class="type">Object attributes:</span> `text-input-type:time`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <p>
-                    <span class="type">Role:</span> `ATK_ROLE_SPINBUTTON`
-                    if implemented as a simple <a class="termref">widget</a>.<br>
-                    If implemented as a complex <a class="termref">widget</a> use:<br>
-                    <span class="type">Role:</span> `ROLE_PANEL` and map child controls as appropriate.
-                  </p>
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXTimeField`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"time field"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-url">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_SPINBUTTON` if implemented as a simple <a class="termref">widget</a>; `ROLE_SYSTEM_GROUPING` with child controls mapped as appropriate if implemented as a complex <a class="termref">widget</a>
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:time`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <p>
+            <span class="type">Role:</span> `ATK_ROLE_SPINBUTTON`
+            if implemented as a simple <a class="termref">widget</a>.<br>
+            If implemented as a complex <a class="termref">widget</a> use:<br>
+            <span class="type">Role:</span> `ROLE_PANEL` and map child controls as appropriate.
+          </p>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXTimeField`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"time field"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-url>`input`<span class="el-context">(`type` attribute in the  URL state with no suggestions source element)</span></h4>
+<table aria-labelledby=el-input-url>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#url-state-(type=url)">URL</a> state with no <a data-cite="html/input.html#concept-input-list">suggestions source element</a>)</span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-textbox">`textbox`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `text-input-type:url`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"url"`</div>
-              </td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-input-week">
-              <th>
-                <a data-cite="html">`input`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:url`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="ctrltype"><span class="type">Localized Control Type:</span> `"url"`</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-input-week>`input`<span class="el-context">  (`type` attribute in the  Week state)</span></h4>
+<table aria-labelledby=el-input-week>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">
                   (<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
                   <a data-cite="html/input.html#week-state-(type=week)">Week</a> state)
                 </span>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-imput-week</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
-                </div>
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `text-input-type:week`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_CALENDAR`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXTextField`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"text field"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-ins">
-              <th>
-                <a data-cite="HTML">`ins`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-insertion">`insertion`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-kbd">
-              <th><a data-cite="HTML">`kbd`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-kbd</div></td>
-              <td class="ia2">
-                <div class="general">No accessible object.</div>
-                <div class="properties">
-                  <span class="type">Text attributes:</span> `font-family:monospace` on the text container
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. Mapped into "font-family:monospace" text attribute on its text container.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-label">
-              <th><a data-cite="HTML">`label`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-label</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_STATICTEXT`; `IA2_ROLE_LABEL`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> 
-                  `IA2_RELATION_LABEL_FOR` with a <a data-cite="html/forms.html#category-label">labelable element</a>
-                  that is child to the `label` or referred to by the `label` element's <a href="#att-for-label">`for`</a> attribute. 
-                  The associated labelable element has `IA2_RELATION_LABELLED_BY` pointing to the `label`.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div>
-                  <span class="type">Relations:</span> 
-                  <div>
-                    When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for 
-                    the element points to the UIA element for the `label` element.
-                  </div>
-                  <div>
-                    When the `label` element has a <a href="#att-for-label">`for`</a> attribute referencing a  
-                    <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for the referenced element points to 
-                    the UIA element for the `label` element.
-                  </div>
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_LABEL`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` for a child <a data-cite="html/forms.html#category-label">labelable element</a> or 
-                  labelable element referred by <a href="#att-for-label">`for`</a> attribute. 
-                  Note, related labelable element provides `ATK_RELATION_LABELLED_BY` pointing to the `label`.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-              <tr tabindex="-1" id="el-legend">
-              <th><a data-cite="HTML">`legend`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-legend</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Roles:</span> `ROLE_SYSTEM_STATICTEXT`; `IA2_ROLE_LABEL`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with the parent <a href="#el-fieldset">`fieldset`</a>
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="properties">
-                  <span class="type">Other properties:</span>
-                  The `LabeledBy` property for the parent
-                  <a href="#el-fieldset">`fieldset`</a> points to the UIA element for the `legend` element.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_LABEL`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span>
-                  `ATK_RELATION_LABEL_FOR` with parent <a href="#el-fieldset">`fieldset`</a> element
-                </div>
-             </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-li">
-              <th>
-                <a data-cite="html">`li`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-listitem">`listitem`</a> role with
-                <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of
-                `li` elements within the parent `ol`, `menu` or `ul`
-                and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a>
-                value reflecting the `li` elements position within the set.
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                If `li` element is not a child of <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing 
-                list element is no longer exposed with a `list` role, then expose the `li` element with a `generic` role.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-link">
-              <th><a data-cite="HTML">`link`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-main">
-              <th><a data-cite="HTML">`main`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-main">`main`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-map">
-              <th><a data-cite="HTML">`map`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-map</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Not mapped if used as an image map. Otherwise,
-                </div>
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_TEXT_FRAME`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">Not mapped</div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Not mapped if used as an image map, otherwise:
-                </div>
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  <span class="type">Role:</span> `AXImageMap` if used as an image map. Otherwise,<br>
-                  <span class="type">Role:</span> `AXGroup` if associated with an `img` with no `alt`. Otherwise,<br>
-                  not mapped if not associated with an `img`.
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-mark">
-              <th><a data-cite="HTML">`mark`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-mark">`mark`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-math">
-              <th>
-                <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
-              </th>
-              <td class="aria">See comments</td>
-              <td class="role-computed"><div class="general">See comments</div></td>
-              <td class="ia2">See comments</td>
-              <td class="uia">See comments</td>
-              <td class="atk">See comments</td>
-              <td class="ax">See comments</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                Mapping for `math` is defined by <a href="https://w3c.github.io/mathml-aam/">MathML AAM 1.0</a>.
-            </tr>
-            <tr tabindex="-1" id="el-menu">
-              <th>
-                <a data-cite="HTML">`menu`</a>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-list">`list`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                <div class="general">
-                  The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a href="#el-ul">`ul`</a> element. 
-                  It has no implemented mappings or behavior that reflect the semantics of the ARIA 
-                  <a class="core-mapping" href="#role-map-menu">`menu`</a> role.
-                </div>
-                <div class="general">
-                  Note obsolete <a data-cite="html/obsolete.html#menuitem">`menuitem` element</a>
-                  and <a data-cite="html/obsolete.html#attr-menu-type">`menu` with `type` attribute</a>.
-                </div>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-meta">
-              <th><a data-cite="HTML">`meta`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-meter">
-              <th><a data-cite="HTML">`meter`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-meter">`meter`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-nav">
-              <th><a data-cite="HTML">`nav`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-navigation">`navigation`</a> role </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-noscript">
-              <th><a data-cite="HTML">`noscript`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-object">
-              <th><a data-cite="HTML">`object`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-object</div></td>
-              <td class="ia2">
-                <div class="general">Depends on format of data file. If it contains a plugin then,</div>
-                <div class="role">
-                  <span class="type">Role:</span> `IA2_ROLE_EMBEDDED_OBJECT`
-                </div>
-                <div class="states">
-                  <span class="type">States:</span>
-                  `STATE_SYSTEM_UNAVAILABLE` for windowless plugin
-                </div>
-              </td>
-              <td class="uia">
-                  <div class="general">Depends on format of data file.</div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Depends on format of data file. If contains a plugin then
-                </div>
-                <div class="role">
-                  <span class="type">Role:</span>
-                  `ATK_ROLE_EMBEDDED`
-                </div>
-              </td>
-              <td class="ax">Depends on format of data file.</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-ol">
-              <th><a data-cite="HTML">`ol`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-list">`list`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-optgroup">
-              <th><a data-cite="HTML">`optgroup`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-group">`group`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-option">
-              <th>
-                <a data-cite="html">`option`</a> <span class="el-context">(in a <a data-cite="html/form-elements.html#concept-select-option-list">list of options</a> or represents a suggestion in a <a data-cite="html">`datalist`</a>)</span>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-option">`option`</a> role, with the <a class="core-mapping" href="#ariaSelectedTrue">`aria-selected`</a> state set to "true" if the element's <a data-cite="html/form-elements.html#concept-option-selectedness">selectedness</a> is true, or "false" otherwise.
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-output">
-              <th><a data-cite="HTML">`output`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-status">`status`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with associated `label` element
-                </div>
-              </td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with associated `label` element
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">Use WAI-ARIA mapping</div>
-                <td class="ax">`AXDescription`: value from associated `label` element subtree.</td>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-p">
-              <th><a data-cite="HTML">`p`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-paragraph">`paragraph`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-param">
-              <th><a data-cite="HTML">`param`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">`param` is obsolete in HTML</td>
-            </tr>
-            <tr tabindex="-1" id="el-picture">
-              <th><a data-cite="HTML">`picture`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-pre">
-              <th><a data-cite="html">`pre`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-progress">
-              <th>
-                <a data-cite="html">`progress`</a>
-              </th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-progressbar">`progressbar`</a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a> property set to the current value of the progress bar
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-q">
-              <th><a data-cite="HTML">`q`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                `::before` and `::after` CSS pseudo content is used by platforms to render the element's quotation marks.
-              </td>
-            </tr>
-            <!--
-              *** Marked as obsolete in HTML. ***
-
-              <tr tabindex="-1" id="el-rb">
-                <th>
-                  <a href="https://html.spec.whatwg.org/#rb">`rb`</a>
-                </th>
-                <td class="aria">No corresponding role</td>
-                <td class="role-computed"><div class="general">html-rb</div></td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type:</span> `Text`
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `AXRubyBase`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="naming"></td>
-                <td class="comments"><a href="https://html.spec.whatwg.org/#rb">Marked as Obsolete in HTML</a>.</td>
-              </tr>
-            -->
-            <tr tabindex="-1" id="el-rp">
-              <th><a data-cite="html">`rp`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">htmp-rp</div></td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. No child elements are exposed if
-                  <a href="#el-ruby">`ruby`</a> is supported by the browser.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object. No child elements are
-                  exposed if <a href="#el-ruby">`ruby`</a> is supported by the browser.
-                </div>
-              </td>
-              <td class="ax">Not mapped</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-rt">
-              <th><a data-cite="HTML">`rt`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-rt</div></td>
-              <td class="ia2">
-                <div class="general">
-                  No accessible object. No child elements are exposed if
-                  <a href="#el-ruby">`ruby`</a> is supported by the browser.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  No accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  No accessible object.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXRubyText`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <!--
-              *** Marked as obsolete in HTML. ***
-
-              <tr tabindex="-1" id="el-rtc">
-                <th>
-                  <a href="https://html.spec.whatwg.org/#rtc">`rtc`</a>
-                </th>
-                <td class="aria">No corresponding role</td>
-                <td class="role-computed"><div class="general">html-rtc</div></td>
-                <td class="ia2">
-                  <div class="role">
-                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                  </div>
-                </td>
-                <td class="uia">
-                  <div class="ctrltype">
-                    <span class="type">Control Type:</span> `Text`
-                  </div>
-                </td>
-                <td class="atk">
-                  <div class="role">
-                    <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `AXRubyBase`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <td class="naming"></td>
-                <td class="comments">
-                  <a href="https://html.spec.whatwg.org/#rtc">Marked as Obsolete in HTML</a>.</td>
-              </tr>
-            -->
-            <tr tabindex="-1" id="el-ruby">
-              <th><a data-cite="HTML">`ruby`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-ruby</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Text`
-                </div>
-                <div class="ctrltype">
-                  <span class="type">Localized Control Type:</span> `"ruby"`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_STATIC`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXRubyInline`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-s">
-              <th><a data-cite="HTML">`s`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-deletion">`deletion`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-samp">
-              <th><a data-cite="HTML">`samp`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-generic">`generic`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-script">
-              <th>
-                <a data-cite="html/scripting.html#the-script-element">`script`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-search">
-              <th><a data-cite="HTML">`search`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-search">`search`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-section">
-              <th><a data-cite="HTML">`section`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an
-                <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-select-listbox">
-              <th>
-                <a data-cite="HTML">`select`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_DATE_EDITOR`
+        </div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `text-input-type:week`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Depends on UI design of implementation. The UI in Windows 10 Edge, for Example, is a composite of multiple spinners.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_CALENDAR`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXTextField`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"text field"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-ins>`ins`</h4>
+<table aria-labelledby=el-ins>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`ins`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-insertion">`insertion`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-kbd>`kbd`</h4>
+<table aria-labelledby=el-kbd>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`kbd`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">No accessible object.</div>
+        <div class="properties">
+          <span class="type">Text attributes:</span> `font-family:monospace` on the text container
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          No accessible object. Mapped into "font-family:monospace" text attribute on its text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-label>`label`</h4>
+<table aria-labelledby=el-label>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`label`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Roles:</span> `ROLE_SYSTEM_STATICTEXT`; `IA2_ROLE_LABEL`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `IA2_RELATION_LABEL_FOR` with a <a data-cite="html/forms.html#category-label">labelable element</a>
+          that is child to the `label` or referred to by the `label` element's <a href="#att-for-label">`for`</a> attribute.
+          The associated labelable element has `IA2_RELATION_LABELLED_BY` pointing to the `label`.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Text`
+        </div>
+        <div>
+          <span class="type">Relations:</span>
+          <div>
+            When the `label` element contains a <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for
+            the element points to the UIA element for the `label` element.
+          </div>
+          <div>
+            When the `label` element has a <a href="#att-for-label">`for`</a> attribute referencing a
+            <a data-cite="html/forms.html#category-label">labelable element</a>, the `LabeledBy` property for the referenced element points to
+            the UIA element for the `label` element.
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_LABEL`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `ATK_RELATION_LABEL_FOR` for a child <a data-cite="html/forms.html#category-label">labelable element</a> or
+          labelable element referred by <a href="#att-for-label">`for`</a> attribute.
+          Note, related labelable element provides `ATK_RELATION_LABELLED_BY` pointing to the `label`.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-legend>`legend`</h4>
+<table aria-labelledby=el-legend>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`legend`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Roles:</span> `ROLE_SYSTEM_STATICTEXT`; `IA2_ROLE_LABEL`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `IA2_RELATION_LABEL_FOR` with the parent <a href="#el-fieldset">`fieldset`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Text`
+        </div>
+        <div class="properties">
+          <span class="type">Other properties:</span>
+          The `LabeledBy` property for the parent
+          <a href="#el-fieldset">`fieldset`</a> points to the UIA element for the `legend` element.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_LABEL`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span>
+          `ATK_RELATION_LABEL_FOR` with parent <a href="#el-fieldset">`fieldset`</a> element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-li>`li`</h4>
+<table aria-labelledby=el-li>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`li`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-listitem">`listitem`</a> role with
+        <a href="https://www.w3.org/TR/core-aam-1.1/#ariaSetsize">`aria-setsize`</a> value reflecting number of
+        `li` elements within the parent `ol`, `menu` or `ul`
+        and <a href="https://www.w3.org/TR/core-aam-1.1/#ariaPosinset">`aria-posinset`</a>
+        value reflecting the `li` elements position within the set.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If `li` element is not a child of <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
+        list element is no longer exposed with a `list` role, then expose the `li` element with a `generic` role.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-link>`link`</h4>
+<table aria-labelledby=el-link>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-main>`main`</h4>
+<table aria-labelledby=el-main>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`main`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-main">`main`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-map>`map`</h4>
+<table aria-labelledby=el-map>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`map`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Not mapped if used as an image map. Otherwise,
+        </div>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_TEXT_FRAME`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Not mapped if used as an image map, otherwise:
+        </div>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_STATIC`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          <span class="type">Role:</span> `AXImageMap` if used as an image map. Otherwise,<br>
+          <span class="type">Role:</span> `AXGroup` if associated with an `img` with no `alt`. Otherwise,<br>
+          not mapped if not associated with an `img`.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-mark>`mark`</h4>
+<table aria-labelledby=el-mark>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`mark`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-mark">`mark`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-math>`math`</h4>
+<table aria-labelledby=el-math>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Mapping for `math` is defined by <a href="https://w3c.github.io/mathml-aam/">MathML AAM 1.0</a>.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-menu>`menu`</h4>
+<table aria-labelledby=el-menu>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`menu`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-list">`list`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">
+          The <a data-cite="HTML">`menu`</a> element is a semantic alternative to the <a href="#el-ul">`ul`</a> element.
+          It has no implemented mappings or behavior that reflect the semantics of the ARIA
+          <a class="core-mapping" href="#role-map-menu">`menu`</a> role.
+        </div>
+        <div class="general">
+          Note obsolete <a data-cite="html/obsolete.html#menuitem">`menuitem` element</a>
+          and <a data-cite="html/obsolete.html#attr-menu-type">`menu` with `type` attribute</a>.
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-meta>`meta`</h4>
+<table aria-labelledby=el-meta>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`meta`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-meter>`meter`</h4>
+<table aria-labelledby=el-meter>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`meter`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-meter">`meter`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-nav>`nav`</h4>
+<table aria-labelledby=el-nav>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`nav`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-navigation">`navigation`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-noscript>`noscript`</h4>
+<table aria-labelledby=el-noscript>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`noscript`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-object>`object`</h4>
+<table aria-labelledby=el-object>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`object`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Depends on format of data file. If it contains a plugin then,</div>
+        <div class="role">
+          <span class="type">Role:</span> `IA2_ROLE_EMBEDDED_OBJECT`
+        </div>
+        <div class="states">
+          <span class="type">States:</span>
+          `STATE_SYSTEM_UNAVAILABLE` for windowless plugin
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Depends on format of data file.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Depends on format of data file. If contains a plugin then
+        </div>
+        <div class="role">
+          <span class="type">Role:</span>
+          `ATK_ROLE_EMBEDDED`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Depends on format of data file.
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-ol>`ol`</h4>
+<table aria-labelledby=el-ol>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`ol`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-list">`list`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-optgroup>`optgroup`</h4>
+<table aria-labelledby=el-optgroup>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`optgroup`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-group">`group`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-option>`option` <span class="el-context">(in a list of options or represents a suggestion in a `datalist`)</span></h4>
+<table aria-labelledby=el-option>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`option`</a> <span class="el-context">(in a <a data-cite="html/form-elements.html#concept-select-option-list">list of options</a> or represents a suggestion in a <a data-cite="html">`datalist`</a>)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-option">`option`</a> role, with the <a class="core-mapping" href="#ariaSelectedTrue">`aria-selected`</a> state set to "true" if the element's <a data-cite="html/form-elements.html#concept-option-selectedness">selectedness</a> is true, or "false" otherwise.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-output>`output`</h4>
+<table aria-labelledby=el-output>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`output`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-status">`status`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with associated `label` element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with associated `label` element
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        `AXDescription`: value from associated `label` element subtree.
+      </td>
+    </tr>
+    <tr>
+      <th>undefined</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-p>`p`</h4>
+<table aria-labelledby=el-p>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`p`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-paragraph">`paragraph`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-param>`param`</h4>
+<table aria-labelledby=el-param>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`param`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        `param` is obsolete in HTML
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-picture>`picture`</h4>
+<table aria-labelledby=el-picture>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`picture`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-pre>`pre`</h4>
+<table aria-labelledby=el-pre>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`pre`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-progress>`progress`</h4>
+<table aria-labelledby=el-progress>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`progress`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-progressbar">`progressbar`</a> role, with, if the progress bar is determinate, the <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a> property set to the maximum value of the progress bar, the <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a> property set to zero, and the <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a> property set to the current value of the progress bar
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-q>`q`</h4>
+<table aria-labelledby=el-q>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`q`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        `::before` and `::after` CSS pseudo content is used by platforms to render the element's quotation marks.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-rp>`rp`</h4>
+<table aria-labelledby=el-rp>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`rp`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          No accessible object. No child elements are exposed if
+          <a href="#el-ruby">`ruby`</a> is supported by the browser.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          No accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          No accessible object. No child elements are
+          exposed if <a href="#el-ruby">`ruby`</a> is supported by the browser.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-rt>`rt`</h4>
+<table aria-labelledby=el-rt>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`rt`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          No accessible object. No child elements are exposed if
+          <a href="#el-ruby">`ruby`</a> is supported by the browser.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          No accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          No accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXRubyText`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-ruby>`ruby`</h4>
+<table aria-labelledby=el-ruby>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`ruby`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Text`
+        </div>
+        <div class="ctrltype">
+          <span class="type">Localized Control Type:</span> `"ruby"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_STATIC`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXRubyInline`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-s>`s`</h4>
+<table aria-labelledby=el-s>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`s`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-deletion">`deletion`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-samp>`samp`</h4>
+<table aria-labelledby=el-samp>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`samp`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-script>`script`</h4>
+<table aria-labelledby=el-script>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/scripting.html#the-script-element">`script`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-search>`search`</h4>
+<table aria-labelledby=el-search>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`search`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-search">`search`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-section>`section`</h4>
+<table aria-labelledby=el-section>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`section`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-region">`region`</a> role if the <a>`section`</a> element has an
+        <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>. Otherwise, the <a class="core-mapping" href="#role-map-generic">`generic`</a> role.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-select-listbox>`select`<span class="el-context">  (with a `multiple` attribute or  `size` attribute having value greater than `1`)</span></h4>
+<table aria-labelledby=el-select-listbox>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`select`</a>
+        <span class="el-context">
                   (with a <a data-cite="html/form-elements.html#attr-select-multiple">`multiple`</a> attribute or
                   <a data-cite="html/form-elements.html#attr-select-size">`size`</a> attribute having value greater than `1`)
                 </span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-listbox">`listbox`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-select-combobox">
-              <th>
-                <a data-cite="HTML">`select`</a>
-                <span class="el-context">
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-listbox">`listbox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-select-combobox>`select`<span class="el-context">  (with NO `multiple`  attribute  and NO `size` attribute having value greater than `1`)</span></h4>
+<table aria-labelledby=el-select-combobox>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`select`</a>
+        <span class="el-context">
                   (with NO <a data-cite="html/form-elements.html#attr-select-multiple">`multiple`</a>  attribute
                   and NO <a data-cite="html/form-elements.html#attr-select-size">`size`</a> attribute having value greater than `1`)
                 </span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-combobox">`combobox`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-slot">
-              <th><a data-cite="HTML">`slot`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-small">
-              <th><a data-cite="HTML">`small`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                Exposed by platform specific font size styles.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-source">
-              <th><a data-cite="HTML">`source`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-span">
-              <th><a data-cite="HTML">`span`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-strong">
-              <th><a data-cite="HTML">`strong`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-strong">`strong`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-style">
-              <th><a data-cite="HTML">`style`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                <div class="general">
-                  <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs.
-                  For instance, `display: none` or `visibility: hidden` will remove an element from the accessibility tree
-                  and hide its presence from assistive technologies.
-                </div>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-sub">
-              <th><a data-cite="html">`sub`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-subscript">`subscript`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-summary">
-              <th>
-                <a data-cite="HTML">`summary`</a>
-              </th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed">
-                <div class="general">
-                  <p>If the element is the first child of its type within a parent `details` element: `html-summary`</p>
-                  <p>Otherwise, if it is not the first child of its type of a parent `details` element, 
-                     or it is not a child of a `details` element: <a class="core-mapping" href="#role-map-generic">`generic`</a> role</p>
-                </div>
-              </td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_PUSHBUTTON`
-                </div>
-                <div class="states">
-                  <span class="type">States:</span>
-                  `STATE_SYSTEM_EXPANDED` / `STATE_SYSTEM_COLLAPSED`
-                </div>
-                <div class="actions">
-                  <span class="type">Actions:</span> `expand` / `collapse`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Button`
-                </div>
-                <div class="ctrlpattern">
-                  <span class="type">Control Pattern:</span> `ExpandCollapse`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_TOGGLE_BUTTON`
-                </div>
-                <div class="relations">
-                  <span class="type">Relations:</span> `ATK_RELATION_DETAILS`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXDisclosureTriangle`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"disclosure triangle"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-sup">
-              <th><a data-cite="html">`sup`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-superscript">`superscript`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-svg">
-              <th><a data-cite="html/embedded-content-other.html#svg-0">`svg`</a></th>
-              <td class="aria">
-                See comments
-              </td>
-              <td class="role-computed"><div class="general">See comments</div></td>
-              <td class="ia2">See comments</td>
-              <td class="uia">See comments</td>
-              <td class="atk">See comments</td>
-              <td class="ax">See comments</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                Mapping for `svg` is defined by [[[svg-aam-1.0]]].
-                See also <a href="https://w3c.github.io/graphics-aam/#mapping_role_table">Graphics Accessibility API Role Mappings</a>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-table">
-              <th><a data-cite="HTML">`table`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-table">`table`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-tbody">
-              <th><a data-cite="HTML">`tbody`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-td">
-              <th>
-                <a data-cite="HTML">`td`</a>
-                (ancestor <a data-cite="HTML">`table`</a> element has
-                <a class="core-mapping" href="#role-map-table">`table`</a> role)
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-cell">`cell`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-td-gridcell">
-              <th>
-                <a data-cite="HTML">`td`</a>
-                (ancestor <a data-cite="HTML">`table`</a> element has
-                <a class="core-mapping" href="#role-map-grid">`grid`</a> or
-                <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-template">
-              <th><a data-cite="HTML">`template`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-textarea">
-              <th><a data-cite="HTML">`textarea`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role,
-                with the <a class="core-mapping" href="#ariaMultilineTrue">`aria-multiline`</a> property set to "true"
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-tfoot">
-              <th><a data-cite="HTML">`tfoot`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-th">
-              <th>
-                <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is not a
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-combobox">`combobox`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-slot>`slot`</h4>
+<table aria-labelledby=el-slot>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`slot`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-small>`small`</h4>
+<table aria-labelledby=el-small>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`small`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Exposed by platform specific font size styles.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-source>`source`</h4>
+<table aria-labelledby=el-source>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`source`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-span>`span`</h4>
+<table aria-labelledby=el-span>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`span`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-strong>`strong`</h4>
+<table aria-labelledby=el-strong>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`strong`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-strong">`strong`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-style>`style`</h4>
+<table aria-labelledby=el-style>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`style`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">
+          <b>Note:</b> There are instances where CSS properties can affect what is exposed by accessibility APIs.
+          For instance, `display: none` or `visibility: hidden` will remove an element from the accessibility tree
+          and hide its presence from assistive technologies.
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-sub>`sub`</h4>
+<table aria-labelledby=el-sub>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`sub`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-subscript">`subscript`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-summary>`summary`</h4>
+<table aria-labelledby=el-summary>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`summary`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_PUSHBUTTON`
+        </div>
+        <div class="states">
+          <span class="type">States:</span>
+          `STATE_SYSTEM_EXPANDED` / `STATE_SYSTEM_COLLAPSED`
+        </div>
+        <div class="actions">
+          <span class="type">Actions:</span> `expand` / `collapse`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Button`
+        </div>
+        <div class="ctrlpattern">
+          <span class="type">Control Pattern:</span> `ExpandCollapse`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_TOGGLE_BUTTON`
+        </div>
+        <div class="relations">
+          <span class="type">Relations:</span> `ATK_RELATION_DETAILS`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXDisclosureTriangle`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"disclosure triangle"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If a `summary` element is not a child of a `details` element, or it is not the first `summary` element of a parent `details`,
+        then the `summary` element MUST be exposed with a `generic` role.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-sup>`sup`</h4>
+<table aria-labelledby=el-sup>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`sup`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-superscript">`superscript`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-svg>`svg`</h4>
+<table aria-labelledby=el-svg>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/embedded-content-other.html#svg-0">`svg`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Mapping for `svg` is defined by [[[svg-aam-1.0]]].
+        See also <a href="https://w3c.github.io/graphics-aam/#mapping_role_table">Graphics Accessibility API Role Mappings</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-table>`table`</h4>
+<table aria-labelledby=el-table>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`table`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-table">`table`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-tbody>`tbody`</h4>
+<table aria-labelledby=el-tbody>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`tbody`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-td>`td`(ancestor `table` element has`table` role)</h4>
+<table aria-labelledby=el-td>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`td`</a>
+        (ancestor <a data-cite="HTML">`table`</a> element has
+        <a class="core-mapping" href="#role-map-table">`table`</a> role)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-cell">`cell`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-td-gridcell>`td`(ancestor `table` element has`grid` or`treegrid` role)</h4>
+<table aria-labelledby=el-td-gridcell>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`td`</a>
+        (ancestor <a data-cite="HTML">`table`</a> element has
+        <a class="core-mapping" href="#role-map-grid">`grid`</a> or
+        <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-template>`template`</h4>
+<table aria-labelledby=el-template>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`template`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-textarea>`textarea`</h4>
+<table aria-labelledby=el-textarea>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-textbox">`textbox`</a> role,
+        with the <a class="core-mapping" href="#ariaMultilineTrue">`aria-multiline`</a> property set to "true"
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-tfoot>`tfoot`</h4>
+<table aria-labelledby=el-tfoot>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`tfoot`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-th>`th`<span class="el-context">(is not a  column header,  row header,  column group header or  row group header,  and ancestor `table` element has  `table` role)</span></h4>
+<table aria-labelledby=el-th>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`th`</a>
+        <span class="el-context">(is not a
                   <a data-cite="HTML/tables.html#column-header">column header</a>,
                   <a data-cite="HTML/tables.html#row-header">row header</a>,
                   <a data-cite="HTML/tables.html#column-group-header">column group header</a> or
@@ -3144,20 +7025,53 @@
                   and ancestor <a data-cite="HTML">`table`</a> element has
                   <a class="core-mapping" href="#role-map-table">`table`</a> role)
                 </span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-cell">`cell`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-th-gridcell">
-              <th>
-                <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is not a
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-cell">`cell`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-th-gridcell>`th`<span class="el-context">(is not a  column header,  row header,  column group header or  row group header,  and ancestor `table` element has  `grid`  or `treegrid` role)</span></h4>
+<table aria-labelledby=el-th-gridcell>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`th`</a>
+        <span class="el-context">(is not a
                   <a data-cite="HTML/tables.html#column-header">column header</a>,
                   <a data-cite="HTML/tables.html#row-header">row header</a>,
                   <a data-cite="HTML/tables.html#column-group-header">column group header</a> or
@@ -3166,228 +7080,644 @@
                   <a class="core-mapping" href="#role-map-grid">`grid`</a>
                   or <a class="core-mapping" href="#role-map-treegrid">`treegrid`</a> role)
                 </span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-th-columnheader">
-              <th>
-                <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is a <a data-cite="HTML/tables.html#column-header">column header</a> or <a data-cite="HTML/tables.html#column-group-header">column group header</a>)</span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-columnheader">`columnheader`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-th-rowheader">
-              <th>
-                <a data-cite="HTML">`th`</a>
-                <span class="el-context">(is a <a data-cite="HTML/tables.html#row-header">row header</a> or <a data-cite="HTML/tables.html#row-group-header">row group header</a>)</span>
-              </th>
-              <td class="aria"><a class="core-mapping" href="#role-map-rowheader">`rowheader`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-thead">
-              <th><a data-cite="HTML">`thead`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-time">
-              <th><a data-cite="HTML">`time`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-time">`time`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-title">
-              <th><a data-cite="HTML">`title`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">A `title` element provides the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for its document.</td>
-            </tr>
-            <tr tabindex="-1" id="el-tr">
-              <th><a data-cite="HTML">`tr`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-row">`row`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-track">
-              <th><a data-cite="HTML">`track`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-u">
-              <th><a data-cite="HTML">`u`</a></th>
-              <td class="aria">
-                <a class="core-mapping" href="#role-map-generic">`generic`</a> role
-              </td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments">
-                Exposed by platform specific underline text styles.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="el-ul">
-              <th><a data-cite="HTML">`ul`</a></th>
-              <td class="aria"><a class="core-mapping" href="#role-map-list">`list`</a> role</td>
-              <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-var">
-              <th><a data-cite="HTML">`var`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-var</div></td>
-              <td class="ia2">
-                <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
-              </td>
-              <td class="uia">
-                <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"group"`
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-video">
-              <th><a data-cite="HTML">`video`</a></th>
-              <td class="aria">No corresponding role</td>
-              <td class="role-computed"><div class="general">html-video</div></td>
-              <td class="ia2">
-                <div class="role">
-                  <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="ctrltype">
-                  <span class="type">Control Type:</span> `Group`
-                </div>
-                <div class="ctrltype"><span class="type">Localized Control Type:</span> `"group"`</div>
-                <div class="general">
-                  <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the <a data-cite="HTML">`video`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
-                </div>
-                <div class="general">Text objects associated with loading or error messages, and any UI control not currently displayed, MAY be present in the <a class="termref">accessibility tree</a> and marked as hidden or off-screen.</div>
-              </td>
-              <td class="atk">
-                <div class="role">
-                  <span class="type">Role:</span> `ATK_ROLE_VIDEO`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXGroup`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `AXVideo`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"video playback"`
-                </div>
-                <div class="general">
-                  <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
-                </div>
-              </td>
-              <!-- <td class="naming"></td> -->
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="el-wbr">
-                <th><a data-cite="HTML">`wbr`</a></th>
-                <td class="aria">No corresponding role</td>
-                <td class="role-computed"><div class="general">Not mapped</div></td>
-                <td class="ia2">
-                  <div class="general">
-                    If a line break is added, expose it with `IAccessibleText` on the text container
-                  </div>
-                </td>
-                <td class="uia"><div class="general">Not mapped</div></td>
-                <td class="atk">
-                  <div class="general">
-                    A line break if added is exposed via Text interface on its text container
-                  </div>
-                </td>
-                <td class="ax">
-                  <div class="role">
-                    <span class="type">AXRole:</span> `AXGroup`
-                  </div>
-                  <div class="subrole">
-                    <span class="type">AXSubrole:</span> `(nil)`
-                  </div>
-                  <div class="roledesc">
-                    <span class="type">AXRoleDescription:</span> `"group"`
-                  </div>
-                </td>
-                <!-- <td class="naming"></td> -->
-                <td class="comments"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-gridcell">`gridcell`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-th-columnheader>`th`<span class="el-context">(is a column header or column group header)</span></h4>
+<table aria-labelledby=el-th-columnheader>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`th`</a>
+        <span class="el-context">(is a <a data-cite="HTML/tables.html#column-header">column header</a> or <a data-cite="HTML/tables.html#column-group-header">column group header</a>)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-columnheader">`columnheader`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-th-rowheader>`th`<span class="el-context">(is a row header or row group header)</span></h4>
+<table aria-labelledby=el-th-rowheader>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`th`</a>
+        <span class="el-context">(is a <a data-cite="HTML/tables.html#row-header">row header</a> or <a data-cite="HTML/tables.html#row-group-header">row group header</a>)</span>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-rowheader">`rowheader`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-thead>`thead`</h4>
+<table aria-labelledby=el-thead>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`thead`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-rowgroup">`rowgroup`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-time>`time`</h4>
+<table aria-labelledby=el-time>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`time`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-time">`time`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-title>`title`</h4>
+<table aria-labelledby=el-title>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`title`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        A `title` element provides the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for its document.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-tr>`tr`</h4>
+<table aria-labelledby=el-tr>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`tr`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-row">`row`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-track>`track`</h4>
+<table aria-labelledby=el-track>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`track`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-u>`u`</h4>
+<table aria-labelledby=el-u>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`u`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-generic">`generic`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Exposed by platform specific underline text styles.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-ul>`ul`</h4>
+<table aria-labelledby=el-ul>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`ul`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-list">`list`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-var>`var`</h4>
+<table aria-labelledby=el-var>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`var`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">No accessible object. Styles used are exposed by UIA text attribute identifiers of the `TextRange` Control Pattern implemented on a parent accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-video>`video`</h4>
+<table aria-labelledby=el-video>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ROLE_SYSTEM_GROUPING`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="ctrltype">
+          <span class="type">Control Type:</span> `Group`
+        </div>
+        <div class="ctrltype"><span class="type">Localized Control Type:</span> `"group"`</div>
+        <div class="general">
+          <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as children of the <a data-cite="HTML">`video`</a> element in the <a class="termref">accessibility tree</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
+        </div>
+        <div class="general">Text objects associated with loading or error messages, and any UI control not currently displayed, MAY be present in the <a class="termref">accessibility tree</a> and marked as hidden or off-screen.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="role">
+          <span class="type">Role:</span> `ATK_ROLE_VIDEO`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `AXVideo`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"video playback"`
+        </div>
+        <div class="general">
+          <b>Note:</b> If the <a data-cite="HTML/media.html#attr-media-controls">`controls`</a> attribute is present, UI controls (e.g., play, volume) are exposed as descendants of an <a class="termref">accessible object</a> with a role of <a class="core-mapping" href="#role-map-toolbar">`toolbar`</a>, and mapped as appropriate for the type of control (e.g., <a class="core-mapping" href="#role-map-button">`button`</a> or <a class="core-mapping" href="#role-map-slider">`slider`</a>).
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=el-wbr>`wbr`</h4>
+<table aria-labelledby=el-wbr>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`wbr`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        No corresponding role
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          If a line break is added, expose it with `IAccessibleText` on the text container
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          A line break if added is exposed via Text interface on its text container
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXGroup`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"group"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
     </section>
     <section>
       <h3>HTML Attribute State and Property Mappings</h3>
@@ -3401,2727 +7731,8423 @@
         </li>
         <li>All elements having an accessible object in IAccessible2 mapping are supposed to implement IAccessible, IAccessible2 and IAccessible2_2 interfaces.</li>
       </ul>
-      <div class="table-container">
-        <table class="map-table attributes" id="attribute-mapping-table">
-          <caption>Mappings of <a data-cite="html/indices.html#attributes-3">HTML attributes (excluding event handler content attributes)</a> to platform <a class="termref">accessibility APIs</a>: ARIA, MSAA + UIA Express, MSAA + IAccessible2, UIA, ATK, and AX </caption>
-          <thead>
-            <tr>
-              <th>Attribute</th>
-              <th>Element(s)</th>
-              <th>[[WAI-ARIA-1.2]]</th>
-              <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
-              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
-              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
-              <th>Comments</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr tabindex="-1" id="att-abbr">
-              <th>`abbr`</th>
-              <td class="elements">
-                <a data-cite="html/tables.html#attr-th-abbr">`th`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span>
-                  "abbr" until child <a href="#el-abbr">`abbr`</a> element is provided
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span>
-                  "abbr" until child <a href="#el-abbr">`abbr`</a> element is provided
-                </div>
-              </td>
-              <td class="ax">`AXDescription: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-accept">
-              <th>`accept`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-accept">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-accept-charset">
-              <th>`accept-charset`</th>
-              <td class="elements">
-                <a data-cite="html/forms.html#attr-form-accept-charset">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-accesskey">
-              <th>`accesskey`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#the-accesskey-attribute">`HTML elements`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  A key binding accessible by
-                  <a href="https://msdn.microsoft.com/en-us/library/accessibility.iaccessible.acckeyboardshortcut.aspx">`accKeyboardShortcut`</a>
-                  and `IAccessibleAction::keyBinding`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="properties">
-                  <span class="type">Properties: </span>`AccessKey: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  `atk_action_get_keybinding`
-                </div>
-              </td>
-              <td class="ax">`AXAccessKey: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-action">
-              <th>`action`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-action">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-allow">
-              <th>`allow`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-allow">`iframe`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-allowfullscreen">
-              <th>`allowfullscreen`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-allowfullscreen">`iframe`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <!-- <tr tabindex="-1" id="att-allowpaymentrequest">
-              <th>`allowpaymentrequest`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-allowpaymentrequest">`iframe`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr> -->
-            <tr tabindex="-1" id="att-alt">
-              <th>`alt`</th>
-              <td class="elements">
-                <a data-cite="html/image-maps.html#attr-area-alt">`area`</a>;
-                <a data-cite="html/embedded-content.html#attr-img-alt">`img`</a>;
-                <a data-cite="html/input.html#attr-input-alt">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>,
-                exposed via <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx">`accName`</a>
-              </td>
-              <td class="uia">
-                <div class="properties">
-                  <span class="type">Properties:</span>
-                  <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx">`Name`</a>
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>, exposed via `atk_object_get_name`
-                </div>
-              </td>
-              <td class="ax">`AXDescription: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-as">
-              <th>`as`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-as">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-async">
-              <th>`async`</th>
-              <td class="elements">
-                <a data-cite="html/scripting.html#attr-script-async">`script`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-autocapitalize">
-              <th>`autocapitalize`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#attr-autocapitalize">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-autocomplete-form">
-              <th>`autocomplete`</th>
-              <td class="elements">
-                <a data-cite="html/forms.html#attr-form-autocomplete">`form`</a>
-              </td>
-              <td class="aria">
-                <p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth">`aria-autocomplete`</a></p>
-                <div class=note>
-                  <strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.
-                </div>
-              </td>
-              <td class="ia2">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `STATE_SUPPORTS_AUTOCOMPLETION` on text form controls until the value is overridden by control
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `ATK_STATE_SUPPORTS_AUTOCOMPLETION` on text form controls until the value is overridden by control
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments">
-                If the element includes both `autocomplete` and `aria-autocomplete` attributes with valid values, 
-                User Agents MUST expose only the `autocomplete` attribute value. The `aria-autocomplete` attribute is 
-                not valid on a `form` element.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-autocomplete">
-              <th>`autocomplete`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-autocomplete">`input`, `select` and `textarea`</a>
-              </td>
-              <td class="aria">
-                <p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth">`aria-autocomplete`</a></p>
-                <div class=note>
-                  <strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.
-                </div>
-              </td>
-              <td class="ia2">
-                <div class="states">
-                  <span class="type">States:</span> `STATE_SUPPORTS_AUTOCOMPLETION`
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="states">
-                  <span class="type">States:</span> `ATK_STATE_SUPPORTS_AUTOCOMPLETION`
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments">
-                If the element includes both `autocomplete` and `aria-autocomplete` attributes with valid values, 
-                User Agents MUST expose only the `autocomplete` attribute value.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-autofocus">
-              <th>`autofocus`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#attr-fe-autofocus">HTML elements</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-autoplay">
-              <th>`autoplay`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-autoplay">`audio` and `video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-blocking">
-              <th>`blocking`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-blocking">`link`</a>;
-                <a data-cite="html/scripting.html#attr-script-defer">`script`</a>;
-                <a data-cite="html/semantics.html#attr-style-media">`style`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-charset-meta">
-              <th>`charset`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-meta-charset">`meta`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-checked">
-              <th>`checked` (if present)</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
-              </td>
-              <td class="aria">
-                <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a>="true"
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">Property: `Toggle.ToggleState: On (1)`</td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax">`AXValue: 1`</td>
-              <td class="comments">
-                If an `input` element in the `checkbox` or `radio` state includes both the `checked` attribute and the `aria-checked` attribute with a 
-                valid value, User Agents MUST expose only the `checked` attribute value.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-checked-absent">
-              <th>`checked` (if absent)</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
-              </td>
-              <td class="aria">
-                <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a>="false"
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia">Property: `Toggle.ToggleState: Off (0)`</td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax">`AXValue: 0`</td>
-              <td class="comments">
-                An `input` element in the `checkbox` or `radio` state without a `checked` attribute has an implicit "false" state. 
-                User Agents MUST ignore an `aria-checked` attribute which conflicts with the native element's implicit checked state.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-cite">
-              <th>`cite`</th>
-              <td class="elements">
-                <a data-cite="html/grouping-content.html#attr-blockquote-cite">`blockquote`</a>;
-                <a data-cite="html/edits.html#attr-mod-cite">`del` and `ins`</a>;
-                <a data-cite="html/text-level-semantics.html#attr-q-cite">`q`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax">`AXURL: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-class">
-              <th>`class`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#classes">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-color">
-              <th>`color`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-color">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-cols">
-              <th>`cols`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-textarea-cols">`textarea`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax">`AXRangeForLine: &lt;value&gt;`</td>
-              <td class="comments"><div class="general">Not mapped</div></td>
-            </tr>
-            <tr tabindex="-1" id="att-colspan">
-              <th>`colspan`</th>
-              <td class="elements">
-                <a data-cite="html/tables.html#attr-tdth-colspan">`td` and `th`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaColSpan">`aria-colspan`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-content">
-              <th>`content`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-meta-content">`meta`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-contenteditable">
-              <th>`contenteditable`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#attr-contenteditable">HTML elements</a>
-              </td>
-              <td class="aria">
-                <!--<p>If in the `true`, `false` or `inherit` state: -->Not mapped<!--</p>
-                <p>If in the `plaintext-only` state: see comments</p>  -->
-              </td>
-              <td class="ia2">
-                <p>If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the 
-                exception of those which have been specified in the `false` state.</p>
-                <div class="states">
-                  <span class="type">States:</span>
-                  `IA2_STATE_EDITABLE` and `IA2_STATE_MULTI_LINE`
-                </div>
-                <div class="interfaces">
-                  <span class="type">Interfaces:</span>
-                  `IAccessibleEditableText`
-                </div>
-                <p>If the element is in the `false` state: not mapped.</p>
-                <p>If the element is in the `inherit` state: match the editable state of its parent element.</p>
-              </td>
-              <td class="uia">
-                <p>If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the 
-                exception of those which have been specified in the `false` state.</p>
-                <div class="ctrltype">
-                  <span class="type">Control Pattern:</span> `TextEdit`
-                </div>
-                <div class="property">
-                  <span class="type">Property:</span> `AriaProperties.multiline:true`
-                </div>
-                <p>If the element is in the `false` state: not mapped.</p>
-                <p>If the element is in the `inherit` state: match the editable state of its parent element.</p>
-              </td>
-              <td class="atk">
-                <p>If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the 
-                exception of those which have been specified in the `false` state.</p>
-                <div class="states">
-                  <span class="type">States:</span>
-                  `ATK_STATE_EDITABLE` and `ATK_STATE_MULTI_LINE`
-                </div>
-                <div class="interfaces">
-                  <span class="type">Interfaces:</span> `AtkEditableText`
-                </div>
-                <p>If the element is in the `false` state: not mapped.</p>
-                <p>If the element is in the `inherit` state: match the editable state of its parent element.</p>
-              </td>
-              <td class="ax">
-                <span class="type">Role:</span>
-                <a href="#el-textarea">AXTextArea</a>
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="comments">
-                If the element is set to `contenteditable`  and `aria-readonly="true"`, User Agents MUST expose only the `contenteditable` state.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-controls">
-              <th>`controls`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax">Controls exposed as `AXToolbar`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-coords">
-              <th>`coords`</th>
-              <td class="elements">
-                <a data-cite="html/image-maps.html#attr-area-coords">`area`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Defines an accessible object's dimensions (`IAccessible::accLocation`)
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Defines an accessible object's dimensions (`BoundingRectangle`)
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Defines an accessible object's dimensions, exposed via `atk_component_get_position` and `atk_component_get_size`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Defines an accessible object's dimensions, exposed via `Frame` property
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-crossorigin">
-              <th>`crossorigin`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-crossorigin">`audio`</a>;
-                <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>;
-                <a data-cite="html/semantics.html#attr-link-crossorigin">`link`</a>;
-                <a data-cite="html/scripting.html#attr-script-crossorigin">`script`</a>;
-                <a data-cite="html/media.html#attr-media-crossorigin">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-data">
-              <th>`data`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-object-data">`object`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-datetime-delins">
-              <th>`datetime`</th>
-              <td class="elements">
-                <a data-cite="html/edits.html#attr-mod-datetime">`del` and `ins`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="ax">`AXDateTimeValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-datetime-time">
-              <th>`datetime`</th>
-              <td class="elements">
-                <a data-cite="html/text-level-semantics.html#attr-time-datetime">`time`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="properties">
-                  <span class="type">Properties:</span> `FullDescription: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="ax">`AXDateTimeValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-decoding">
-              <th>`decoding`</th>
-              <td class="elements">
-                <a data-cite="html/embedded-content.html#attr-img-decoding">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-default">
-              <th>`default`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-track-default">`track`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-defer">
-              <th>`defer`</th>
-              <td class="elements">
-                <a data-cite="html/scripting.html#attr-script-defer">`script`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-dir">
-              <th>`dir`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#the-dir-attribute">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as "writing-mode" text attribute on the text container.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Exposed by `TextFlowDirections` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as "writing-mode" text attribute on the text container.
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-dir-bdo">
-              <th>`dir`</th>
-              <td class="elements">
-                <a data-cite="HTML">`bdo`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as "writing-mode" text attribute on the text container.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Exposed by `TextFlowDirections` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as "writing-mode" text attribute on the text container.
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-dirname">
-              <th>`dirname`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-dirname">`input` and
-                `textarea`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-disabled">
-              <th>`disabled`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-optgroup-disabled">`optgroup`</a>;
-                <a data-cite="html/form-elements.html#attr-option-disabled">`option`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`select`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`textarea`</a>;
-                <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">
-                If the element has both the `disabled` attribute and the `aria-disabled` attribute with a valid value, 
-                User Agents MUST expose only the `disabled` attribute value.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-disabled-fieldset">
-              <th>`disabled`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-fieldset-disabled">`fieldset`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">
-                <p>Form controls within a valid [^legend^] child element of a `fieldset` with a `disabled` attribute 
-                  do not become disabled.</p>
-                <p>If the element has both the `disabled` attribute and the `aria-disabled` attribute with a valid value, 
-                  User Agents MUST expose only the `disabled` attribute value.</p>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-disabled-link">
-              <th>`disabled`</th>
-              <td class="elements">
-                <a data-cite="HTML">`link`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2">Not mapped</td>
-              <td class="uia">Not mapped</td>
-              <td class="atk">Not mapped</td>
-              <td class="ax">Not mapped</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-download">
-              <th>`download`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#attr-hyperlink-download">`a` and `area`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-draggable">
-              <th>`draggable`</th>
-              <td class="elements">
-                <a data-cite="html/dnd.html#the-draggable-attribute">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="objattrs">
-                  <span class="objattrs">Object attributes:</span> draggable:true
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="objattrs">
-                  <span class="objattrs">Object attributes:</span> draggable:true
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-enctype">
-              <th>`enctype`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-enctype">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-enterkeyhint">
-              <th>`enterkeyhint`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#attr-enterkeyhint">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments">Modifies the action label (or icon) to present for the 
-                <kbd>enter</kbd> key on virtual keyboards.</td>
-            </tr>
-            <tr tabindex="-1" id="att-fetchpriority">
-              <th>`fetchpriority`</th>
-              <td class="elements">
-                <a data-cite="html/embedded-content.html#attr-img-fetchpriority">`img`</a>;
-                <a data-cite="html/semantics.html#attr-link-fetchpriority">`link`</a>;
-                <a data-cite="html/scripting.html#attr-script-fetchpriority">`script`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-for-label">
-              <th>`for`</th>
-              <td class="elements">
-                <a data-cite="html/forms.html#attr-label-for">`label`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="name">
-                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-                <div class="relations">
-                  <span class="type">Relations: </span>
-                  `IA2_RELATION_LABEL_FOR` and `IA2_RELATION_LABEL_BY` relations between
-                  <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
-                </div>
-              </td>
-              <td class="uia">
-                <div class="name">
-                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-                <div class="relations">
-                  When the `label` element has a `for` attribute referencing another <a data-cite="html/forms.html#category-label">labelable element</a>,
-                  the `LabeledBy` property for the referenced element points to the UIA element for the `label` element.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="name">
-                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-                <div class="relations">
-                  <span class="type">Relations: </span>
-                  `ATK_RELATION_LABEL_FOR` and `ATK_RELATION_LABEL_BY` relations between
-                  <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
-                </div>
-              </td>
-              <td class="ax">
-                <div class="name">
-                  Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-for-output">
-              <th>`for`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-output-for">`output`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="relations">
-                  <span class="type">Relations: </span>
-                  `IA2_RELATION_CONTROLLED_BY` with an element pointed by the attribute. Paired element exposes `IA2_RELATION_CONTROLLER_FOR` relation.
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="relations">
-                  <span class="type">Relations: </span>
-                  `ATK_RELATION_CONTROLLED_BY` with an element pointed by the attribute. Paired element exposes `ATK_RELATION_CONTROLLER_FOR` relation.
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-form">
-              <th>`form`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`fieldset`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`input`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`label`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`object`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`output`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`select`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`textarea`</a>;
-                <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-formaction">
-              <th>`formaction`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formaction">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formaction">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-formenctype">
-              <th>`formenctype`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formenctype">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formenctype">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-formmethod">
-              <th>`formmethod`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formmethod">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formmethod">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-formnovalidate">
-              <th>`formnovalidate`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formnovalidate">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formnovalidate">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-formtarget">
-              <th>`formtarget`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-formtarget">`button`</a>; <a data-cite="html/form-control-infrastructure.html#attr-fs-formtarget">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-headers">
-              <th>`headers`</th>
-              <td class="elements">
-                <a data-cite="html/tables.html#attr-tdth-headers">`td`</a>;
-                <a data-cite="html/tables.html#attr-tdth-headers">`th`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Links the cell to its header cells. Exposed via `IAccessibleTableCell::rowHeaderCells` and `IAccessibleTableCell::columnHeaderCells`.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Links the cell to its header cells. Exposed via `Table.ItemColumnHeaderItems` and `Table.ItemRowHeaderItems`.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Links the cell to its row and <a data-cite="HTML/tables.html#column-header">column header</a> cells
-                  (note, only one row and one column header cells can be exposed because of API restrictions).
-                  See `atk_table_get_row_header` and `atk_table_get_column_header`.
-                </div>
-              </td>
-              <td class="ax">Expose via `AXColumnHeaderUIElements` and `AXRowHeaderUIElements`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-height">
-              <th>`height`</th>
-              <td class="elements">
-                <a data-cite="html/canvas.html#attr-canvas-height">`canvas`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`embed`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`iframe`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`img`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`input`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`object`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`source` (in `picture`)</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-height">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Defines an accessible object's height (`IAccessible::accLocation`)
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Defines an accessible object's height (`BoundingRectangle`)
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Defines an accessible object's height (`atk_component_get_size`)
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Defines an accessible object's height
-                  (`AXSize` property)
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-hidden">
-              <th>
-                <a data-cite="html/interaction.html#the-hidden-attribute">`hidden`</a>
-              </th>
-              <td class="elements">
-                <a data-cite="html/infrastructure.html#html-elements">HTML elements</a>
-              </td>
-              <td class="aria">
-                <a class="core-mapping" href="#ariaHiddenTrue">`aria-hidden="true"`</a> if the element retains its user agent default styling of `display: none`. Otherwise, if no other method for hiding the content is used (e.g., `visibility: hidden`) then it is not mapped.
-              </td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-high">
-              <th>`high`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-meter-high">`meter`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia">`RangeValue.Maximum`</td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-href">
-              <th><a data-cite="html/links.html#attr-hyperlink-href">`href`</a></th>
-              <td class="elements">`a`; `area`</td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Creates a link accessible object. For details, refer to
-                  <a href="#el-a">`a`</a> and <a href="#el-area">`area`</a> element mappings.
-                </div>
-              </td>
-              <td class="uia">Creates a link accessible object. For details, refer to
-                  <a href="#el-a">`a`</a> and <a href="#el-area">`area`</a> element mappings. The value of the `href` attribute is stored in the `Value.Value` UIA property.
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Creates a link accessible object. For details, refer to
-                  <a href="#el-a">`a`</a> and <a href="#el-area">`area`</a> element mappings.
-                </div>
-              </td>
-              <td class="ax">`AXURL: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-href-link">
-              <th>`href`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-href">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-hreflang">
-              <th>`hreflang`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#attr-hyperlink-hreflang">`a`</a>;
-                <!-- area removed in living standard -->
-                <a data-cite="html/semantics.html#attr-link-hreflang">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-http-equiv">
-              <th>`http-equiv`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-meta-http-equiv">`meta`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-id">
-              <th>`id`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#the-id-attribute">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-inert">
-              <th>`inert`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#the-inert-attribute">HTML elements</a>
-              </td>
-              <td class="aria">Not Mapped</td>
-              <td class="ia2">See comments</td>
-              <td class="uia">See comments</td>
-              <td class="atk">See comments</td>
-              <td class="ax">See comments</td>
-              <td class="comments">
-                <p>
-                  Nodes that are <a data-cite="html/interaction.html#inert">inert</a> are not exposed to an accessibility API.
-                </p>
-                <p class="note">
-                  Note: an inert node can have descendants that are not inert. For example, a
-                  <a data-cite="html/interaction.html#modal-dialogs-and-inert-subtrees">modal dialog</a>
-                  can escape an inert subtree.
-                </p>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-indeterminate">
-              <th>`indeterminate [IDL]`</th>
-              <td class="elements">
-                HTML elements;
-                <a data-cite="html/input.html#dom-input-indeterminate">`input`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="mixed"</td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
-              <td class="comments">If the element has the `indeterminate [IDL]` set and the `aria-checked` attribute set, User Agents MUST expose only the`indeterminate [IDL]` state.</td>
-            </tr>
-            <tr tabindex="-1" id="att-ismap">
-              <th>`ismap`</th>
-              <td class="elements">
-                <a data-cite="html/embedded-content.html#attr-img-ismap">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-itemid">
-              <th>`itemid`</th>
-              <td class="elements">
-                <a data-cite="html/microdata.html#attr-itemid">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-itemprop">
-              <th>`itemprop`</th>
-              <td class="elements">
-                <a data-cite="html/microdata.html#attr-itemprop">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-itemref">
-              <th>`itemref`</th>
-              <td class="elements">
-                <a data-cite="html/microdata.html#attr-itemref">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-itemscope">
-              <th>`itemscope`</th>
-              <td class="elements">
-                <a data-cite="html/microdata.html#attr-itemscope">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-itemtype">
-              <th>`itemtype`</th>
-              <td class="elements">
-                <a data-cite="html/microdata.html#attr-itemtype">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-kind">
-              <th>`kind`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-track-kind">`track`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2">Not mapped</td>
-              <td class="uia">Not mapped</td>
-              <td class="atk">Not mapped</td>
-              <td class="ax">Not mapped</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-label">
-              <th>`label`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-optgroup-label">`optgroup`</a>;
-                <a data-cite="html/form-elements.html#attr-option-label">`option`</a>;
-                <a data-cite="html/media.html#attr-track-label">`track`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="name">
-                  Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-              </td>
-              <td class="uia">
-                The target element of the `label` attribute has a `LabeledBy` property pointing to the element with the `label` attribute. Participates in <a href="#accname-computation">name computation.</a>
-              </td>
-              <td class="atk">
-                <div class="name">
-                  Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-              </td>
-              <td class="ax">`AXTitle`: `&lt;value&gt;`</td>
-              <td class="comments">
-                See Also: <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-lang">
-              <th>`lang`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#attr-lang">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="textattrs">
-                  Exposed as "language" text attribute on the text container
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  The value of the `lang` attribute is exposed as a locale identifier by `Culture` property of the UIA element representing the HTML element, and by `Culture` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
-                </div>
-               <td class="atk">
-                <div class="textattrs">
-                  Exposed as "language" text attribute on the text container
-                </div>
-              </td>
-              <td class="ax">`AXLanguage: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-list">
-              <th>`list`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-list">`input`</a>
-              </td>
-              <td class="aria">
-                <a class="core-mapping" href="#ariaControls">`aria-controls`</a>
-              </td>
-              <td class="ia2">
-                <div class="relations">
-                  `IA2_RELATION_CONTROLLER_FOR` point to the `datalist` element referred to by the IDREF value of the `list` attribute.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="relations">
-                  `ControllerFor` point to the `datalist` element referred to by the IDREF value of the `list` attribute.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="relations">
-                  `ATK_RELATION_CONTROLLER_FOR` point to the `datalist` element referred to by the IDREF value of the `list` attribute.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Property: `AXLinkedUIElements`: point to the `datalist` element referred to by the IDREF value of the `list` attribute.
-                </div>
-              </td>
-              <td class="comments">
-                Refer to <a href="#el-datalist">`datalist`</a> 
-                and <a href="#el-input-textetc-autocomplete">`input`</a> element mappings.
-              </td>
-            </tr>
-            <!-- <tr tabindex="-1" id="att-longdesc">
-              <th>`longdesc`</th>
-              <td class="elements">
-                `img`,
-                <a href="https://www.w3.org/TR/html4/present/frames.html#edef-FRAME">`frame`</a>, `iframe`</td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="actions">
-                  <span class="type">Actions: </span>
-                  showlongdesc (exposed on <a href="#el-img">`img`</a> only)
-                </div>
-              </td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk">
-                <div class="actions">
-                  <span class="type">Actions: </span>
-                  showlongdesc (exposed on <a href="#el-img">`img`</a> only)
-                </div>
-              </td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments">IE 8+ populates the accdescription with the value of the longdesc attribute. This is brittle as it is overwritten when aria-describedby is used. </td>
-            </tr> -->
-            <tr tabindex="-1" id="att-loop">
-              <th>`loop`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-loop">`audio`</a>;
-                <a data-cite="html/media.html#attr-media-loop">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-low">
-              <th>`low`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-meter-low">`meter`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">`RangeValue.Minimum`</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-max-input">
-              <th>`max`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-max">`input`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as `IAccessibleValue::maximumValue` if the element implements the interface
-                </div>
-              </td>
-              <td class="uia">`RangeValue.Maximum`</td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface
-                </div>
-              </td>
-              <td class="ax">`AXMaxValue: &lt;value&gt;`</td>
-                <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-max">
-              <th>`max`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-meter-max">`meter`</a>;
-                <a data-cite="html/form-elements.html#attr-progress-max">`progress`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as `IAccessibleValue::maximumValue` if the element implements the interface
-                </div>
-              </td>
-              <td class="uia">`RangeValue.Maximum`</td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface
-                </div>
-              </td>
-              <td class="ax">`AXMaxValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-maxlength">
-              <th>`maxlength`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-maxlength">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-textarea-maxlength">`textarea`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-media">
-              <th>`media`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-media">`link`</a>;
-                <a data-cite="html/semantics.html#attr-meta-media">`meta`</a>;
-                <a data-cite="html/embedded-content.html#attr-source-media">`source` (in `picture`)</a>;
-                <a data-cite="html/semantics.html#attr-style-media">`style`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-method">
-              <th>`method`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-method">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-min-input">
-              <th>`min`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-min">`input`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as `IAccessibleValue::minimumValue` if the element
-                  implements the interface
-                </div>
-              </td>
-              <td class="uia">`RangeValue.Minimum`</td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as `atk_value_get_minimum_value` if the element
-                  implements the `AtkValue` interface
-                </div>
-              </td>
-              <td class="ax">`AXMinValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-min">
-              <th>`min`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-meter-min">`meter`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as `IAccessibleValue::minimumValue` if the element implements the interface
-                </div>
-              </td>
-              <td class="uia">`RangeValue.Minimum`</td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as `atk_value_get_minimum_value` if the element implements the `AtkValue` interface
-                </div>
-              </td>
-              <td class="ax">`AXMinValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-minlength">
-              <th>`minlength`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-minlength">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-textarea-minlength">`textarea`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `IA2_STATE_INVALID_ENTRY` if value doesn't meet the designated minimum length value.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `IsDataValidForForm` if value doesn't meet the designated minimum length value.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="states">
-                  <span class="type">States:</span>
-                  `ATK_STATE_INVALID_ENTRY` if value doesn't meet the designated minimum length value.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="property">
-                  <span class="type">Property:</span>
-                  `AXInvalid`: `true` if value doesn't meet the designated minimum length value.
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-multiple-input">
-              <th>`multiple`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-multiple">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-multiple-select">
-              <th>`multiple`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-select-multiple">`select`</a>
-              </td>
-              <td class="aria">
-                <a data-cite="wai-aria-1.2/#aria-multiselectable">`aria-multiselectable="true"`</a>
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-muted">
-              <th>`muted`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-muted">`audio`</a>;
-                <a data-cite="html/media.html#attr-media-muted">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-name">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`button`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`fieldset`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`input`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`output`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`select`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`textarea`</a>;
-                <a data-cite="html/form-control-infrastructure.html#attr-fe-name">form-associated custom element</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-name-form">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/forms.html#attr-form-name">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-name-iframe">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-name">`iframe`</a>;
-                <a data-cite="html/iframe-embed-object.html#attr-object-name">`object`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-name-map">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/image-maps.html#attr-map-name">`map`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-name-meta">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-meta-name">`meta`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <!-- the param element is obsolete            
-            <tr tabindex="-1" id="att-name-param">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-param-name">`param`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr> 
-            -->
-            <tr tabindex="-1" id="att-name-slot">
-              <th>`name`</th>
-              <td class="elements">
-                <a data-cite="html/scripting.html#attr-slot-name">`slot`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-nomodule">
-              <th>`nomodule`</th>
-              <td class="elements">
-                <a data-cite="html/scripting.html#attr-script-nomodule">`script`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-nonce">
-              <th>`nonce`</th>
-              <td class="elements">
-                <a data-cite="html/urls-and-fetching.html#attr-nonce">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-novalidate">
-              <th>`novalidate`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-novalidate">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-open-details">
-              <th>`open`</th>
-              <td class="elements">
-                <a data-cite="html/interactive-elements.html#attr-details-open">`details`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded`</a>="true | false"</td>
-              <td class="ia2">`STATE_SYSTEM_EXPANDED`<br />`STATE_SYSTEM_COLLAPSED`</td>
-              <td class="uia">
-                <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.expandcollapsepattern.aspx">`ExpandCollapsePattern`</a>
-              </td>
-              <td class="atk">
-                <div class="states">
-                  <span class="type">States: </span>
-                  `ATK_STATE_COLLAPSED` or `ATK_STATE_EXPANDED` depending
-                  on the attribute value
-                </div>
-              </td>
-              <td class="ax">`AXExpanded: YES|NO`</td>
-              <td class="comments">Set properties on the <a href="#el-summary">`summary`</a> element.</td>
-            </tr>
-            <tr tabindex="-1" id="att-open-dialog">
-              <th>`open`</th>
-              <td class="elements"><a data-cite="html/interactive-elements.html#attr-dialog-open">`dialog`</a></td>
-              <td class="aria">
-                <div class="general">
-                  If the `open` attribute is set via the `showModal()` method then <a class="core-mapping" href="#ariaModalTrue">`aria-modal="true"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
-                </div>
-                <div class="general">
-                  Otherwise, if the `open` attribute is set via the `show()` method, or explicitly specified by an author, then <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
-                </div>
-              </td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
-              <td class="comments">
-                <p>
-                  The `open` attribute's value is irrelevant. When the `open` attribute is not specified the default user agent styling for a `dialog` is `display: none`.
-                </p>
-                <p>
-                  Authors can reveal a `dialog` through the style layer by modifying its `display` property. If revealed this way then the `dialog` is <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
-                </p>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-optimum">
-              <th>`optimum`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-meter-optimum">`meter`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-pattern">
-              <th>`pattern`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-pattern">`input`</a>
-              </td>
-              <td class="aria">
-                <div class="general">
-                  If the value doesn't match the pattern: <a class="core-mapping" href="#ariaInvalidTrue">`aria-invalid="true"`</a>;
-                  Otherwise, <a class="core-mapping" href="#ariaInvalidFalse">`aria-invalid="false"`</a>
-                </div>
-              </td>
-              <td class="ia2">Use WAI-ARIA mapping</td>
-              <td class="uia">Use WAI-ARIA mapping</td>
-              <td class="atk">Use WAI-ARIA mapping</td>
-              <td class="ax">Use WAI-ARIA mapping</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-ping">
-              <th>`ping`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#ping">`a` and `area`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-placeholder">
-              <th>`placeholder`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-placeholder">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-textarea-placeholder">`textarea`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaPlaceholder">`aria-placeholder`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">
-                <div class="general">When the `placeholder` and `aria-placeholder` attributes are both present, and the `placeholder` attribute's value is non-empty, user agents MUST expose the value of the `placeholder` attribute, and ignore `aria-placeholder`. If the `placeholder` attribute's value is empty, then user agents MUST expose the value of the `aria-placeholder` attribute.</div>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-playsinline">
-              <th>`playsinline`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-video-playsinline">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-poster">
-              <th>`poster`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-video-poster">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-preload">
-              <th>`preload`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-preload">`audio` and `video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-readonly">
-              <th>`readonly`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-readonly">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-textarea-readonly">`textarea`</a>;
-                <a data-cite="html/custom-elements.html#attr-face-readonly">form-associated custom elements</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaReadonlyTrue">`aria-readonly="true"`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">If the element includes both the `readonly` attribute and the `aria-readonly` attribute with a valid value, User Agents MUST expose only the `readonly` attribute value.</td>
-            </tr>
-            <tr tabindex="-1" id="att-referrerpolicy">
-              <th>`referrerpolicy`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#attr-hyperlink-referrerpolicy">`a`</a>;
-                <a data-cite="html/links.html#attr-hyperlink-referrerpolicy">`area`</a>;
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-referrerpolicy">`iframe`</a>;
-                <a data-cite="html/embedded-content.html#attr-img-referrerpolicy">`img`</a>;
-                <a data-cite="html/semantics.html#attr-link-referrerpolicy">`link`</a>;
-                <a data-cite="html/scripting.html#attr-script-referrerpolicy">`script`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-rel">
-              <th>`rel`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#attr-hyperlink-rel">`a`</a>;
-                <a data-cite="html/links.html#attr-hyperlink-rel">`area`</a>;
-                <a data-cite="html/semantics.html#attr-link-rel">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-required">
-              <th>`required`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-required">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-select-required">`select`</a>;
-                <a data-cite="html/form-elements.html#attr-textarea-required">`textarea`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaRequiredTrue">`aria-required`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">
-                If the element includes both the `required` attribute and the `aria-required` attribute with a valid value, User Agents MUST expose only the `required` attribute value.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-reversed">
-              <th>`reversed`</th>
-              <td class="elements">
-                <a data-cite="html/grouping-content.html#attr-ol-reversed">`ol`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Reverses the numerical or alphabetical order of the child list item markers.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Reverses the numerical or alphabetical order of the child list item markers.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Reverses the numerical or alphabetical order of the child list item markers.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Reverses the numerical or alphabetical order of the child list item markers.
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-rows">
-              <th>`rows`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-textarea-rows">`textarea`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-rowspan">
-              <th>`rowspan`</th>
-              <td class="elements">
-                <a data-cite="html/tables.html#attr-tdth-rowspan">`td`</a>;
-                <a data-cite="html/tables.html#attr-tdth-rowspan">`th`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaRowSpan">`aria-rowspan`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-sandbox">
-              <th>`sandbox`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-sandbox">`iframe`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-scope">
-              <th>`scope`</th>
-              <td class="elements">
-                <a data-cite="html/tables.html#attr-th-scope">`th`</a>
-              </td>
-              <td class="aria">
-                <div class="general">
-                  If `scope="row"` then map `th` to <a class="core-mapping" href="#role-map-columnheader">`rowheader`</a>
-                </div>
-                <div class="general">
-                  If `scope="col"` then map `th` to <a class="core-mapping" href="#role-map-columnheader">`columnheader`</a>
-                </div>
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-selected">
-              <th>`selected`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-option-selected">`option`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaSelectedTrue">`aria-selected="true"`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments">If the element includes both the `selected` attribute and the `aria-selected` attribute with a valid value, User Agents MUST expose only the `selected` attribute value.</td>
-            </tr>
-            <tr tabindex="-1" id="att-shape">
-              <th>`shape`</th>
-              <td class="elements">
-                <a data-cite="html/image-maps.html#attr-area-shape">`area`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-size">
-              <th>`size`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-size">`input`</a>;
-                <a data-cite="html/form-elements.html#attr-select-size">`select`</a>
-              </td>
-              <td class="aria">
-                <div class="general">
-                  Not mapped for `input` elements.
-                </div>
-                <div class="general">
-                  If greater than 1, then creates a listbox accessible object. Refer to <a href="#el-select-listbox">`select`</a> element for details.
-                </div>
-              </td>
-              <td class="ia2">
-                <div class="general">Not mapped for `input` elements.</div>
-                <div class="general">For `select` element use WAI-ARIA mapping.</div>
-              </td>
-              <td class="uia">
-                <div class="general">Not mapped for `input` elements.</div>
-                <div class="general">For `select` element use WAI-ARIA mapping.</div>
-              </td>
-              <td class="atk">
-                <div class="general">Not mapped for `input` elements.</div>
-                <div class="general">For `select` element use WAI-ARIA mapping.</div>
-              </td>
-              <td class="ax">
-                <div class="general">Not mapped for `input` elements.</div>
-                <div class="general">For `select` element use WAI-ARIA mapping.</div>
-              </td>
-              <td class="comments">
-                For `input` elements that allow the `size` attribute, the attribute will modify their default width. A width provided by CSS will negate the effects of the `size` attribute on these `input` elements.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-sizes">
-              <th>`sizes`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-sizes">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-sizes-img-source">
-              <th>`sizes`</th>
-              <td class="elements">
-                <a data-cite="html/embedded-content.html#attr-img-sizes">`img`</a>;
-                <a data-cite="html/embedded-content.html#attr-source-sizes">`source`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-slot">
-              <th>`slot`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#attr-slot">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-span">
-              <th>`span`</th>
-              <td class="elements">
-                <a data-cite="html/tables.html#attr-col-span">`col`</a>;
-                <a data-cite="html/tables.html#attr-colgroup-span">`colgroup`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as `IAccessibleTableCell::columnExtent` on all cells at the column
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Exposed as `GridItem.ColumnSpan` on all cells at the column
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Exposed via `atk_table_get_column_extent_at`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  `AXColumnIndexRange.length: &lt;value>`
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-spellcheck">
-              <th>`spellcheck`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#attr-spellcheck">HTML elements</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaInvalidSpellingGrammar">`aria-invalid="spelling"` or `grammar`</a></td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-src-media">
-              <th>`src`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-media-src">`audio`</a>;
-                <a data-cite="html/iframe-embed-object.html#attr-embed-src">`embed`</a>;
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-src">`iframe`</a>;
-                <a data-cite="html/embedded-content.html#attr-img-src">`img`</a>;
-                <a data-cite="html/input.html#attr-input-src">`input`</a>;
-                <a data-cite="html/scripting.html#attr-script-src">`script`</a>;
-                <a data-cite="html/embedded-content.html#attr-source-src">`source` (in `audio` or `video`)</a>;
-                <a data-cite="html/media.html#attr-track-src">`track`</a>;
-                <a data-cite="html/media.html#attr-media-src">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span>
-                  `src` on <a href="#el-img">`img`</a> only
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">Not mapped</div>
-              </td>
-              <td class="atk">
-                <div class="objattrs">
-                  <span class="type">Object attributes:</span>
-                  `src` on <a href="#el-img">`img`</a> only
-                </div>
-              </td>
-              <td class="ax">
-                `AXURL: &lt;value&gt;` on <a href="#el-img">`img`</a> and <a href="#el-input-image">`input type="image"`</a>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-srcdoc">
-              <th>`srcdoc`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-iframe-srcdoc">`iframe`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-srclang">
-              <th>`srclang`</th>
-              <td class="elements">
-                <a data-cite="html/media.html#attr-track-srclang">`track`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-srcset">
-              <th>`srcset`</th>
-              <td class="elements">
-                <a data-cite="html/embedded-content.html#attr-img-srcset">`img`</a>;
-                <a data-cite="html/embedded-content.html#attr-source-srcset">`source`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not Mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-start">
-              <th>`start`</th>
-              <td class="elements">
-                <a data-cite="html/grouping-content.html#attr-ol-start">`ol`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Changes the first number of the child list item accessible objects to match the `start` attribute's value.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Changes the first number of the child list item accessible objects to match the `start` attribute's value.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Changes the first number of the child list item accessible objects to match the `start` attribute's value.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Changes the first number of the child list item accessible objects to match the `start` attribute's value.
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-step">
-              <th>`step`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-step">`input`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia">
-                If the `input` is in the <a href="#el-input-range">`Range`</a> state, set both `RangeValue.SmallChange` and `RangeValue.LargeChange` to the value of `step`.
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as `atk_value_get_minimum_increment` if the element implements the `AtkValue` interface.
-                </div>
-              </td>
-              <td class="ax">Not mapped</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-style">
-              <th>`style`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#the-style-attribute">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-tabindex">
-              <th>`tabindex`</th>
-              <td class="elements">
-                <a data-cite="html/interaction.html#attr-tabindex">HTML elements</a>
-              </td>
-              <td class="aria">
-                <a class="core-mapping" href="#focus_state_event_table">See Focus States and Events Table</a>
-              </td>
-              <td class="ia2"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="uia"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="atk"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="ax"><div class="general">Use WAI-ARIA mapping</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-target">
-              <th>`target`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#attr-hyperlink-target">`a`</a>;
-                <a data-cite="html/links.html#attr-hyperlink-target">`area`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-target-base">
-              <th>`target`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-base-target">`base`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-target-form">
-              <th>`target`</th>
-              <td class="elements">
-                <a data-cite="html/form-control-infrastructure.html#attr-fs-target">`form`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-title">
-              <th>`title`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#attr-title">HTML elements</a>
-              </td>
-              <td class="aria">
-                <div class="general">
-                  Either the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>, or the
-                  <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>, or Not mapped (see Comments).
-                </div>
-              </td>
-              <td class="ia2">
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="uia">
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="atk">
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="ax">
-                <div class="general">Use WAI-ARIA mapping</div>
-              </td>
-              <td class="comments">
-                <div class="general">
-                  The <a href="#accessible-name-and-description-computation">Accessible Name and Description Computation</a> section specifies if the `title` attribute will be mapped and, if so, through what [[WAI-ARIA]] property.
-                </div>
-
-                <!--
-                    TODO for issue #260
-                  -->
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-title-abbr">
-              <th>`title`</th>
-              <td class="elements">
-                <a data-cite="html/text-level-semantics.html#attr-abbr-title">`abbr`</a>;
-                <a data-cite="html/text-level-semantics.html#attr-dfn-title">`dfn`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="name">
-                  Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-              </td>
-              <td class="uia">
-                <div class="name">
-                  Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-              </td>
-              <td class="atk">
-                <div class="name">
-                  Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-                </div>
-              </td>
-              <td class="ax">`AXExpandedTextValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-title-link">
-              <th>`title`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-title">`link`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2">Not mapped</td>
-              <td class="uia">Not mapped</td>
-              <td class="atk">Not mapped</td>
-              <td class="ax">Not mapped</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-title-style">
-              <th>`title`</th>
-              <td class="elements">
-                <a data-cite="html/semantics.html#attr-link-title">`link`</a>; <a data-cite="html/semantics.html#attr-style-title">`style`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments">
-                Provides the name for the CSS style sheet.
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-translate">
-              <th>`translate`</th>
-              <td class="elements">
-                <a data-cite="html/dom.html#attr-translate">HTML elements</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-type-hyperlink">
-              <th>`type`</th>
-              <td class="elements">
-                <a data-cite="html/links.html#attr-hyperlink-type">`a`</a>;
-                <a data-cite="html/semantics.html#attr-link-type">`link`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-type-button">
-              <th>`type`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-button-type">`button`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2">
-                <div class="general">
-                  <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-type-embed">
-              <th>`type`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-embed-type">`embed`</a>;
-                <a data-cite="html/iframe-embed-object.html#attr-object-type">`object`</a>;
-                <a data-cite="html/scripting.html#attr-script-type">`script`</a>;
-                <a data-cite="html/embedded-content.html#attr-source-type">`source`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-type-input">
-              <th>`type`</th>
-              <td>
-                <a data-cite="html/input.html#attr-input-type">`input`</a>
-              </td>
-              <td class="aria">Refer to WAI-ARIA mappings for input types with defined ARIA roles.</td>
-              <td class="ia2">
-                <div class="general">
-                  Defines the accessible role, states and other properties, refer to
-                  type="<a href="#el-input-text">`text`</a>",
-                  type="<a href="#el-input-password">`password`</a>",
-                  type="<a href="#el-input-button">`button`</a>", etc
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Defines the accessible role, states and other properties, refer to
-                  type="<a href="#el-input-text">`text`</a>",
-                  type="<a href="#el-input-password">`password`</a>",
-                  type="<a href="#el-input-button">`button`</a>", etc
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Defines the accessible role, states and other properties, refer to
-                  type="<a href="#el-input-text">`text`</a>",
-                  type="<a href="#el-input-password">`password`</a>",
-                  type="<a href="#el-input-button">`button`</a>", etc
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Defines the accessible role, states and other properties, refer to
-                  type="<a href="#el-input-text">`text`</a>",
-                  type="<a href="#el-input-password">`password`</a>",
-                  type="<a href="#el-input-button">`button`</a>", etc
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-type-ol">
-              <th>`type`</th>
-              <td class="elements">
-                <a data-cite="html/grouping-content.html#attr-ol-type">`ol`</a>
-              </td>
-              <td class="aria">Not mapped</td>
-              <td class="ia2">
-                <div class="general">
-                  Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `IAccessibleText2`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
-                </div>
-                <div class="ctrlpattern"><span class="type">Control Pattern:</span> `Text`</div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
-                </div>
-                <div class="ifaces">
-                  <span class="type">Interfaces:</span> `ATKText`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">Defines the list item marker, which is exposed as content in `AXValue`, and rendered as an <a class="termref">accessible object</a>:</div>
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXListMarker`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `"list marker"`
-                </div>
-              </td>
-              <td class="comments">
-                <div class="general">Some platforms (IAccessible2, ATK, UIA) do not expose an <a class="termref">accessible object</a> for the list item marker, whether it was created and then pruned from the <a class="termref">accessibility tree</a>, or never created in the first place. Instead, they expose the list item marker as part of the associated list item's accessible text. In these cases, implementors need to consider such things as adjusting the offsets (e.g., for caret-moved events, text-selection events, etc.) for the updated list item text that now also contains the list item marker as content, rather than just taking the offsets unmodified from the list item renderer.</div>
-              </td>
-            </tr>
-            <tr tabindex="-1" id="att-usemap">
-              <th>`usemap`</th>
-              <td class="elements">
-                <a data-cite="html/image-maps.html#attr-hyperlink-usemap">`img`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Responsible for image map creation.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Responsible for image map creation.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Responsible for image map creation.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  Responsible for image map creation.
-                </div>
-              </td>
-              <td class="comments">Refer to <a href="#el-img">`img`</a> element.</td>
-            </tr>
-            <tr tabindex="-1" id="att-value-button">
-              <th>`value`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-button-value">`button`</a>;
-                <a data-cite="html/form-elements.html#attr-option-value">`option`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-value-data">
-              <th>`value`</th>
-              <td class="elements">
-                <a data-cite="html/text-level-semantics.html#attr-data-value">`data`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-value-input">
-              <th>`value`</th>
-              <td class="elements">
-                <a data-cite="html/input.html#attr-input-value">`input`</a>
-              </td>
-              <td class="aria">Not mapped</td> <!-- related: https://github.com/w3c/aria/issues/711 -->
-              <td class="ia2">
-                <div class="name">
-                  Associates the accessible value for entry type input elements
-                  and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
-                </div>
-              </td>
-              <td class="uia">
-                <div class="name">
-                  Associates the accessible value for entry type input elements
-                  and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
-                </div>
-              </td>
-              <td class="atk">
-                <div class="name">
-                  Associates the accessible value for entry type input elements
-                  and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
-                </div>
-              </td>
-              <td class="ax">`AXValue: &lt;value&gt;`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-value-li">
-              <th>`value`</th>
-              <td class="elements">
-                <a data-cite="html/grouping-content.html#attr-li-value">`li`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as first text node of `li`'s accessible object.
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Expose the value of the `value` attribute as the first text node in the list item. 
-                  If the value of the `value` attribute is an integer, set the UIA `PositionInSet` property to the integer value.
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as first text node of `li`'s accessible object.
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">Exposed as `AXValue: &lt;value&gt;` with accessible object:</div>
-                <div class="role">
-                  <span class="type">AXRole:</span> `AXListMarker`
-                </div>
-                <div class="subrole">
-                  <span class="type">AXSubrole:</span> `(nil)`
-                </div>
-                <div class="roledesc">
-                  <span class="type">AXRoleDescription:</span> `list marker`
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-value-meter">
-              <th>`value`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-meter-value">`meter`</a>;
-                <a data-cite="html/form-elements.html#attr-progress-value">`progress`</a>
-              </td>
-              <td class="aria"><a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a></td>
-              <td class="ia2">
-                <div class="general">
-                  Exposed as `IAccessibleValue::currentValue`
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Exposed as `Value.Value`
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Exposed as `atk_value_get_current_value`
-                </div>
-              </td>
-              <td class="ax">
-                <div class="general">
-                  `AXValue: &lt;value&gt;`
-                </div>
-              </td>
-              <td class="comments"></td>
-            </tr>
-            <!-- param is obsolete 
-            <tr tabindex="-1" id="att-value-param">
-              <th>`value`</th>
-              <td class="elements">
-                <a data-cite="html/iframe-embed-object.html#attr-param-value">`param`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr> -->
-            <tr tabindex="-1" id="att-width">
-              <th>`width`</th>
-              <td class="elements">
-                <a data-cite="html/canvas.html#attr-canvas-width">`canvas`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`embed`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`iframe`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`img`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`input`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`object`</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`source` (in `picture`)</a>;
-                <a data-cite="html/embedded-content-other.html#attr-dim-width">`video`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2">
-                <div class="general">
-                  Defines an accessible object's width (`IAccessible::accLocation`)
-                </div>
-              </td>
-              <td class="uia">
-                <div class="general">
-                  Defines an accessible object's width (`BoundingRectangle`)
-                </div>
-              </td>
-              <td class="atk">
-                <div class="general">
-                  Defines an accessible object's width (`atk_component_get_size`)
-                </div>
-              </td>
-              <td class="ax">`AXSize: w=<i>n</i>`</td>
-              <td class="comments"></td>
-            </tr>
-            <tr tabindex="-1" id="att-wrap">
-              <th>`wrap`</th>
-              <td class="elements">
-                <a data-cite="html/form-elements.html#attr-textarea-wrap">`textarea`</a>
-              </td>
-              <td class="aria"><div class="general">Not mapped</div></td>
-              <td class="ia2"><div class="general">Not mapped</div></td>
-              <td class="uia"><div class="general">Not mapped</div></td>
-              <td class="atk"><div class="general">Not mapped</div></td>
-              <td class="ax"><div class="general">Not mapped</div></td>
-              <td class="comments"></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+<h4 id=att-abbr>`abbr`</h4>
+<table aria-labelledby=att-abbr>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `abbr`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/tables.html#attr-th-abbr">`th`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span>
+          "abbr" until child <a href="#el-abbr">`abbr`</a> element is provided
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span>
+          "abbr" until child <a href="#el-abbr">`abbr`</a> element is provided
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXDescription: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-accept>`accept`</h4>
+<table aria-labelledby=att-accept>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `accept`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-accept">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-accept-charset>`accept-charset`</h4>
+<table aria-labelledby=att-accept-charset>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `accept-charset`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/forms.html#attr-form-accept-charset">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-accesskey>`accesskey`</h4>
+<table aria-labelledby=att-accesskey>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `accesskey`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#the-accesskey-attribute">`HTML elements`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          A key binding accessible by
+          <a href="https://msdn.microsoft.com/en-us/library/accessibility.iaccessible.acckeyboardshortcut.aspx">`accKeyboardShortcut`</a>
+          and `IAccessibleAction::keyBinding`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="properties">
+          <span class="type">Properties: </span>`AccessKey: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          `atk_action_get_keybinding`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXAccessKey: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-action>`action`</h4>
+<table aria-labelledby=att-action>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `action`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-action">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-allow>`allow`</h4>
+<table aria-labelledby=att-allow>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `allow`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-allow">`iframe`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-allowfullscreen>`allowfullscreen`</h4>
+<table aria-labelledby=att-allowfullscreen>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `allowfullscreen`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-allowfullscreen">`iframe`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-alt>`alt`</h4>
+<table aria-labelledby=att-alt>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `alt`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/image-maps.html#attr-area-alt">`area`</a>;
+        <a data-cite="html/embedded-content.html#attr-img-alt">`img`</a>;
+        <a data-cite="html/input.html#attr-input-alt">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>,
+        exposed via <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx">`accName`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="properties">
+          <span class="type">Properties:</span>
+          <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.automationelement.automationelementinformation.name.aspx">`Name`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>, exposed via `atk_object_get_name`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXDescription: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-as>`as`</h4>
+<table aria-labelledby=att-as>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `as`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-as">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-async>`async`</h4>
+<table aria-labelledby=att-async>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `async`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/scripting.html#attr-script-async">`script`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-autocapitalize>`autocapitalize`</h4>
+<table aria-labelledby=att-autocapitalize>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `autocapitalize`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#attr-autocapitalize">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-autocomplete-form>`autocomplete`</h4>
+<table aria-labelledby=att-autocomplete-form>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `autocomplete`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/forms.html#attr-form-autocomplete">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth">`aria-autocomplete`</a></p>
+        <div class=note>
+          <strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span>
+          `STATE_SUPPORTS_AUTOCOMPLETION` on text form controls until the value is overridden by control
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span>
+          `ATK_STATE_SUPPORTS_AUTOCOMPLETION` on text form controls until the value is overridden by control
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element includes both `autocomplete` and `aria-autocomplete` attributes with valid values,
+        User Agents MUST expose only the `autocomplete` attribute value. The `aria-autocomplete` attribute is
+        not valid on a `form` element.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-autocomplete>`autocomplete`</h4>
+<table aria-labelledby=att-autocomplete>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `autocomplete`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-autocomplete">`input`, `select` and `textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <p><a class="core-mapping" href="#ariaAutocompleteInlineListBoth">`aria-autocomplete`</a></p>
+        <div class=note>
+          <strong>Note:</strong> the ARIA attribute and the HTML attribute have disparate features.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span> `STATE_SUPPORTS_AUTOCOMPLETION`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span> `ATK_STATE_SUPPORTS_AUTOCOMPLETION`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element includes both `autocomplete` and `aria-autocomplete` attributes with valid values,
+        User Agents MUST expose only the `autocomplete` attribute value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-autofocus>`autofocus`</h4>
+<table aria-labelledby=att-autofocus>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `autofocus`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#attr-fe-autofocus">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-autoplay>`autoplay`</h4>
+<table aria-labelledby=att-autoplay>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `autoplay`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-autoplay">`audio` and `video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-blocking>`blocking`</h4>
+<table aria-labelledby=att-blocking>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `blocking`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-blocking">`link`</a>;
+        <a data-cite="html/scripting.html#attr-script-defer">`script`</a>;
+        <a data-cite="html/semantics.html#attr-style-media">`style`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-charset-meta>`charset`</h4>
+<table aria-labelledby=att-charset-meta>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `charset`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-meta-charset">`meta`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-checked>`checked` (if present)</h4>
+<table aria-labelledby=att-checked>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `checked` (if present)
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a>="true"
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Property: `Toggle.ToggleState: On (1)`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXValue: 1`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If an `input` element in the `checkbox` or `radio` state includes both the `checked` attribute and the `aria-checked` attribute with a
+        valid value, User Agents MUST expose only the `checked` attribute value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-checked-absent>`checked` (if absent)</h4>
+<table aria-labelledby=att-checked-absent>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `checked` (if absent)
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox` or `type=radio`
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaCheckedFalse">`aria-checked`</a>="false"
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Property: `Toggle.ToggleState: Off (0)`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXValue: 0`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        An `input` element in the `checkbox` or `radio` state without a `checked` attribute has an implicit "false" state.
+        User Agents MUST ignore an `aria-checked` attribute which conflicts with the native element's implicit checked state.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-cite>`cite`</h4>
+<table aria-labelledby=att-cite>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `cite`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/grouping-content.html#attr-blockquote-cite">`blockquote`</a>;
+        <a data-cite="html/edits.html#attr-mod-cite">`del` and `ins`</a>;
+        <a data-cite="html/text-level-semantics.html#attr-q-cite">`q`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXURL: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-class>`class`</h4>
+<table aria-labelledby=att-class>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `class`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#classes">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-color>`color`</h4>
+<table aria-labelledby=att-color>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `color`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-color">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-cols>`cols`</h4>
+<table aria-labelledby=att-cols>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `cols`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-textarea-cols">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXRangeForLine: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-colspan>`colspan`</h4>
+<table aria-labelledby=att-colspan>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `colspan`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/tables.html#attr-tdth-colspan">`td` and `th`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaColSpan">`aria-colspan`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-content>`content`</h4>
+<table aria-labelledby=att-content>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `content`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-meta-content">`meta`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-contenteditable>`contenteditable`</h4>
+<table aria-labelledby=att-contenteditable>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `contenteditable`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#attr-contenteditable">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <p>If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the
+          exception of those which have been specified in the `false` state.</p>
+        <div class="states">
+          <span class="type">States:</span>
+          `IA2_STATE_EDITABLE` and `IA2_STATE_MULTI_LINE`
+        </div>
+        <div class="interfaces">
+          <span class="type">Interfaces:</span>
+          `IAccessibleEditableText`
+        </div>
+        <p>If the element is in the `false` state: not mapped.</p>
+        <p>If the element is in the `inherit` state: match the editable state of its parent element.</p>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <p>If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the
+          exception of those which have been specified in the `false` state.</p>
+        <div class="ctrltype">
+          <span class="type">Control Pattern:</span> `TextEdit`
+        </div>
+        <div class="property">
+          <span class="type">Property:</span> `AriaProperties.multiline:true`
+        </div>
+        <p>If the element is in the `false` state: not mapped.</p>
+        <p>If the element is in the `inherit` state: match the editable state of its parent element.</p>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <p>If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the
+          exception of those which have been specified in the `false` state.</p>
+        <div class="states">
+          <span class="type">States:</span>
+          `ATK_STATE_EDITABLE` and `ATK_STATE_MULTI_LINE`
+        </div>
+        <div class="interfaces">
+          <span class="type">Interfaces:</span> `AtkEditableText`
+        </div>
+        <p>If the element is in the `false` state: not mapped.</p>
+        <p>If the element is in the `inherit` state: match the editable state of its parent element.</p>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <span class="type">Role:</span>
+        <a href="#el-textarea">AXTextArea</a>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element is set to `contenteditable` and `aria-readonly="true"`, User Agents MUST expose only the `contenteditable` state.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-controls>`controls`</h4>
+<table aria-labelledby=att-controls>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `controls`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-controls">`audio` and `video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Controls exposed as `AXToolbar`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-coords>`coords`</h4>
+<table aria-labelledby=att-coords>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `coords`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/image-maps.html#attr-area-coords">`area`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's dimensions (`IAccessible::accLocation`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's dimensions (`BoundingRectangle`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's dimensions, exposed via `atk_component_get_position` and `atk_component_get_size`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's dimensions, exposed via `Frame` property
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-crossorigin>`crossorigin`</h4>
+<table aria-labelledby=att-crossorigin>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `crossorigin`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-crossorigin">`audio`</a>;
+        <a data-cite="html/embedded-content.html#attr-img-crossorigin">`img`</a>;
+        <a data-cite="html/semantics.html#attr-link-crossorigin">`link`</a>;
+        <a data-cite="html/scripting.html#attr-script-crossorigin">`script`</a>;
+        <a data-cite="html/media.html#attr-media-crossorigin">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-data>`data`</h4>
+<table aria-labelledby=att-data>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `data`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-object-data">`object`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-datetime-delins>`datetime`</h4>
+<table aria-labelledby=att-datetime-delins>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `datetime`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/edits.html#attr-mod-datetime">`del` and `ins`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXDateTimeValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-datetime-time>`datetime`</h4>
+<table aria-labelledby=att-datetime-time>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `datetime`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/text-level-semantics.html#attr-time-datetime">`time`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="properties">
+          <span class="type">Properties:</span> `FullDescription: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `datetime: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXDateTimeValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-decoding>`decoding`</h4>
+<table aria-labelledby=att-decoding>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `decoding`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/embedded-content.html#attr-img-decoding">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-default>`default`</h4>
+<table aria-labelledby=att-default>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `default`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-track-default">`track`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-defer>`defer`</h4>
+<table aria-labelledby=att-defer>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `defer`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/scripting.html#attr-script-defer">`script`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-dir>`dir`</h4>
+<table aria-labelledby=att-dir>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `dir`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#the-dir-attribute">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as "writing-mode" text attribute on the text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Exposed by `TextFlowDirections` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as "writing-mode" text attribute on the text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-dir-bdo>`dir`</h4>
+<table aria-labelledby=att-dir-bdo>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `dir`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="HTML">`bdo`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as "writing-mode" text attribute on the text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Exposed by `TextFlowDirections` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as "writing-mode" text attribute on the text container.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-dirname>`dirname`</h4>
+<table aria-labelledby=att-dirname>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `dirname`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-dirname">`input` and
+          `textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-disabled>`disabled`</h4>
+<table aria-labelledby=att-disabled>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `disabled`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-optgroup-disabled">`optgroup`</a>;
+        <a data-cite="html/form-elements.html#attr-option-disabled">`option`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`select`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`textarea`</a>;
+        <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element has both the `disabled` attribute and the `aria-disabled` attribute with a valid value,
+        User Agents MUST expose only the `disabled` attribute value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-disabled-fieldset>`disabled`</h4>
+<table aria-labelledby=att-disabled-fieldset>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `disabled`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-fieldset-disabled">`fieldset`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaDisabledTrue">`aria-disabled="true"`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <p>Form controls within a valid [^legend^] child element of a `fieldset` with a `disabled` attribute
+          do not become disabled.</p>
+        <p>If the element has both the `disabled` attribute and the `aria-disabled` attribute with a valid value,
+          User Agents MUST expose only the `disabled` attribute value.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-disabled-link>`disabled`</h4>
+<table aria-labelledby=att-disabled-link>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `disabled`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="HTML">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-download>`download`</h4>
+<table aria-labelledby=att-download>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `download`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-download">`a` and `area`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-draggable>`draggable`</h4>
+<table aria-labelledby=att-draggable>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `draggable`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dnd.html#the-draggable-attribute">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="objattrs">Object attributes:</span> draggable:true
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="objattrs">Object attributes:</span> draggable:true
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-enctype>`enctype`</h4>
+<table aria-labelledby=att-enctype>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `enctype`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-enctype">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-enterkeyhint>`enterkeyhint`</h4>
+<table aria-labelledby=att-enterkeyhint>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `enterkeyhint`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#attr-enterkeyhint">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Modifies the action label (or icon) to present for the
+        <kbd>enter</kbd> key on virtual keyboards.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-fetchpriority>`fetchpriority`</h4>
+<table aria-labelledby=att-fetchpriority>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `fetchpriority`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/embedded-content.html#attr-img-fetchpriority">`img`</a>;
+        <a data-cite="html/semantics.html#attr-link-fetchpriority">`link`</a>;
+        <a data-cite="html/scripting.html#attr-script-fetchpriority">`script`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-for-label>`for`</h4>
+<table aria-labelledby=att-for-label>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `for`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/forms.html#attr-label-for">`label`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="name">
+          Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+        <div class="relations">
+          <span class="type">Relations: </span>
+          `IA2_RELATION_LABEL_FOR` and `IA2_RELATION_LABEL_BY` relations between
+          <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="name">
+          Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+        <div class="relations">
+          When the `label` element has a `for` attribute referencing another <a data-cite="html/forms.html#category-label">labelable element</a>,
+          the `LabeledBy` property for the referenced element points to the UIA element for the `label` element.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="name">
+          Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+        <div class="relations">
+          <span class="type">Relations: </span>
+          `ATK_RELATION_LABEL_FOR` and `ATK_RELATION_LABEL_BY` relations between
+          <a href="#el-label">`label`</a> and referred <a data-cite="html/forms.html#category-label">labelable element</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="name">
+          Used for <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-for-output>`for`</h4>
+<table aria-labelledby=att-for-output>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `for`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-output-for">`output`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="relations">
+          <span class="type">Relations: </span>
+          `IA2_RELATION_CONTROLLED_BY` with an element pointed by the attribute. Paired element exposes `IA2_RELATION_CONTROLLER_FOR` relation.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="relations">
+          <span class="type">Relations: </span>
+          `ATK_RELATION_CONTROLLED_BY` with an element pointed by the attribute. Paired element exposes `ATK_RELATION_CONTROLLER_FOR` relation.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-form>`form`</h4>
+<table aria-labelledby=att-form>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `form`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`fieldset`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`input`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`label`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`object`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`output`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`select`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fae-form">`textarea`</a>;
+        <a data-cite="html/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-formaction>`formaction`</h4>
+<table aria-labelledby=att-formaction>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `formaction`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formaction">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formaction">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-formenctype>`formenctype`</h4>
+<table aria-labelledby=att-formenctype>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `formenctype`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formenctype">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formenctype">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-formmethod>`formmethod`</h4>
+<table aria-labelledby=att-formmethod>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `formmethod`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formmethod">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formmethod">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-formnovalidate>`formnovalidate`</h4>
+<table aria-labelledby=att-formnovalidate>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `formnovalidate`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formnovalidate">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formnovalidate">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-formtarget>`formtarget`</h4>
+<table aria-labelledby=att-formtarget>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `formtarget`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-formtarget">`button`</a>; <a data-cite="html/form-control-infrastructure.html#attr-fs-formtarget">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-headers>`headers`</h4>
+<table aria-labelledby=att-headers>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `headers`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/tables.html#attr-tdth-headers">`td`</a>;
+        <a data-cite="html/tables.html#attr-tdth-headers">`th`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Links the cell to its header cells. Exposed via `IAccessibleTableCell::rowHeaderCells` and `IAccessibleTableCell::columnHeaderCells`.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Links the cell to its header cells. Exposed via `Table.ItemColumnHeaderItems` and `Table.ItemRowHeaderItems`.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Links the cell to its row and <a data-cite="HTML/tables.html#column-header">column header</a> cells
+          (note, only one row and one column header cells can be exposed because of API restrictions).
+          See `atk_table_get_row_header` and `atk_table_get_column_header`.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Expose via `AXColumnHeaderUIElements` and `AXRowHeaderUIElements`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-height>`height`</h4>
+<table aria-labelledby=att-height>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `height`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/canvas.html#attr-canvas-height">`canvas`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`embed`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`iframe`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`img`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`input`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`object`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`source` (in `picture`)</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-height">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's height (`IAccessible::accLocation`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's height (`BoundingRectangle`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's height (`atk_component_get_size`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's height
+          (`AXSize` property)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-hidden>`hidden`</h4>
+<table aria-labelledby=att-hidden>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/interaction.html#the-hidden-attribute">`hidden`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/infrastructure.html#html-elements">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaHiddenTrue">`aria-hidden="true"`</a> if the element retains its user agent default styling of `display: none`. Otherwise, if no other method for hiding the content is used (e.g., `visibility: hidden`) then it is not mapped.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-high>`high`</h4>
+<table aria-labelledby=att-high>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `high`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-meter-high">`meter`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        `RangeValue.Maximum`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-href>`href`</h4>
+<table aria-labelledby=att-href>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        `a`; `area`
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Creates a link accessible object. For details, refer to
+          <a href="#el-a">`a`</a> and <a href="#el-area">`area`</a> element mappings.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Creates a link accessible object. For details, refer to
+        <a href="#el-a">`a`</a> and <a href="#el-area">`area`</a> element mappings. The value of the `href` attribute is stored in the `Value.Value` UIA property.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Creates a link accessible object. For details, refer to
+          <a href="#el-a">`a`</a> and <a href="#el-area">`area`</a> element mappings.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXURL: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-href-link>`href`</h4>
+<table aria-labelledby=att-href-link>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `href`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-href">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-hreflang>`hreflang`</h4>
+<table aria-labelledby=att-hreflang>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `hreflang`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-hreflang">`a`</a>;
+        <a data-cite="html/semantics.html#attr-link-hreflang">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-http-equiv>`http-equiv`</h4>
+<table aria-labelledby=att-http-equiv>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `http-equiv`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-meta-http-equiv">`meta`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-id>`id`</h4>
+<table aria-labelledby=att-id>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `id`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#the-id-attribute">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-inert>`inert`</h4>
+<table aria-labelledby=att-inert>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `inert`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#the-inert-attribute">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not Mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        See comments
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <p>
+          Nodes that are <a data-cite="html/interaction.html#inert">inert</a> are not exposed to an accessibility API.
+        </p>
+        <p class="note">
+          Note: an inert node can have descendants that are not inert. For example, a
+          <a data-cite="html/interaction.html#modal-dialogs-and-inert-subtrees">modal dialog</a>
+          can escape an inert subtree.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-indeterminate>`indeterminate [IDL]`</h4>
+<table aria-labelledby=att-indeterminate>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `indeterminate [IDL]`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        HTML elements;
+        <a data-cite="html/input.html#dom-input-indeterminate">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaCheckedTrue">`aria-checked`</a> (state)="mixed"
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element has the `indeterminate [IDL]` set and the `aria-checked` attribute set, User Agents MUST expose only the`indeterminate [IDL]` state.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-ismap>`ismap`</h4>
+<table aria-labelledby=att-ismap>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `ismap`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/embedded-content.html#attr-img-ismap">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-itemid>`itemid`</h4>
+<table aria-labelledby=att-itemid>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `itemid`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/microdata.html#attr-itemid">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-itemprop>`itemprop`</h4>
+<table aria-labelledby=att-itemprop>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `itemprop`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/microdata.html#attr-itemprop">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-itemref>`itemref`</h4>
+<table aria-labelledby=att-itemref>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `itemref`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/microdata.html#attr-itemref">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-itemscope>`itemscope`</h4>
+<table aria-labelledby=att-itemscope>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `itemscope`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/microdata.html#attr-itemscope">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-itemtype>`itemtype`</h4>
+<table aria-labelledby=att-itemtype>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `itemtype`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/microdata.html#attr-itemtype">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-kind>`kind`</h4>
+<table aria-labelledby=att-kind>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `kind`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-track-kind">`track`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-label>`label`</h4>
+<table aria-labelledby=att-label>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `label`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-optgroup-label">`optgroup`</a>;
+        <a data-cite="html/form-elements.html#attr-option-label">`option`</a>;
+        <a data-cite="html/media.html#attr-track-label">`track`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="name">
+          Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        The target element of the `label` attribute has a `LabeledBy` property pointing to the element with the `label` attribute. Participates in <a href="#accname-computation">name computation.</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="name">
+          Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXTitle`: `&lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        See Also: <a href="" class="accname">Accessible Name and Description: Computation and API Mappings 1.1</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-lang>`lang`</h4>
+<table aria-labelledby=att-lang>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `lang`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#attr-lang">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="textattrs">
+          Exposed as "language" text attribute on the text container
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          The value of the `lang` attribute is exposed as a locale identifier by `Culture` property of the UIA element representing the HTML element, and by `Culture` attribute of the `TextRange` Control Pattern implemented on a parent accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="textattrs">
+          Exposed as "language" text attribute on the text container
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXLanguage: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-list>`list`</h4>
+<table aria-labelledby=att-list>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `list`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-list">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaControls">`aria-controls`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="relations">
+          `IA2_RELATION_CONTROLLER_FOR` point to the `datalist` element referred to by the IDREF value of the `list` attribute.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="relations">
+          `ControllerFor` point to the `datalist` element referred to by the IDREF value of the `list` attribute.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="relations">
+          `ATK_RELATION_CONTROLLER_FOR` point to the `datalist` element referred to by the IDREF value of the `list` attribute.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Property: `AXLinkedUIElements`: point to the `datalist` element referred to by the IDREF value of the `list` attribute.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Refer to <a href="#el-datalist">`datalist`</a>
+        and <a href="#el-input-textetc-autocomplete">`input`</a> element mappings.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-loop>`loop`</h4>
+<table aria-labelledby=att-loop>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `loop`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-loop">`audio`</a>;
+        <a data-cite="html/media.html#attr-media-loop">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-low>`low`</h4>
+<table aria-labelledby=att-low>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `low`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-meter-low">`meter`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">`RangeValue.Minimum`</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-max-input>`max`</h4>
+<table aria-labelledby=att-max-input>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `max`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-max">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as `IAccessibleValue::maximumValue` if the element implements the interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        `RangeValue.Maximum`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXMaxValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-max>`max`</h4>
+<table aria-labelledby=att-max>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `max`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-meter-max">`meter`</a>;
+        <a data-cite="html/form-elements.html#attr-progress-max">`progress`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaValueMax">`aria-valuemax`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as `IAccessibleValue::maximumValue` if the element implements the interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        `RangeValue.Maximum`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as `atk_value_get_maximum_value` if the element implements the `AtkValue` interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXMaxValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-maxlength>`maxlength`</h4>
+<table aria-labelledby=att-maxlength>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `maxlength`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-maxlength">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-textarea-maxlength">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-media>`media`</h4>
+<table aria-labelledby=att-media>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `media`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-media">`link`</a>;
+        <a data-cite="html/semantics.html#attr-meta-media">`meta`</a>;
+        <a data-cite="html/embedded-content.html#attr-source-media">`source` (in `picture`)</a>;
+        <a data-cite="html/semantics.html#attr-style-media">`style`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-method>`method`</h4>
+<table aria-labelledby=att-method>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `method`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-method">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-min-input>`min`</h4>
+<table aria-labelledby=att-min-input>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `min`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-min">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as `IAccessibleValue::minimumValue` if the element
+          implements the interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        `RangeValue.Minimum`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as `atk_value_get_minimum_value` if the element
+          implements the `AtkValue` interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXMinValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-min>`min`</h4>
+<table aria-labelledby=att-min>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `min`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-meter-min">`meter`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaValueMin">`aria-valuemin`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as `IAccessibleValue::minimumValue` if the element implements the interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        `RangeValue.Minimum`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as `atk_value_get_minimum_value` if the element implements the `AtkValue` interface
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXMinValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-minlength>`minlength`</h4>
+<table aria-labelledby=att-minlength>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `minlength`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-minlength">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-textarea-minlength">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span>
+          `IA2_STATE_INVALID_ENTRY` if value doesn't meet the designated minimum length value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span>
+          `IsDataValidForForm` if value doesn't meet the designated minimum length value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States:</span>
+          `ATK_STATE_INVALID_ENTRY` if value doesn't meet the designated minimum length value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="property">
+          <span class="type">Property:</span>
+          `AXInvalid`: `true` if value doesn't meet the designated minimum length value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-multiple-input>`multiple`</h4>
+<table aria-labelledby=att-multiple-input>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `multiple`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-multiple">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-multiple-select>`multiple`</h4>
+<table aria-labelledby=att-multiple-select>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `multiple`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-select-multiple">`select`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a data-cite="wai-aria-1.2/#aria-multiselectable">`aria-multiselectable="true"`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-muted>`muted`</h4>
+<table aria-labelledby=att-muted>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `muted`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-muted">`audio`</a>;
+        <a data-cite="html/media.html#attr-media-muted">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-name>`name`</h4>
+<table aria-labelledby=att-name>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `name`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`button`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`fieldset`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`input`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`output`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`select`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">`textarea`</a>;
+        <a data-cite="html/form-control-infrastructure.html#attr-fe-name">form-associated custom element</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-name-form>`name`</h4>
+<table aria-labelledby=att-name-form>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `name`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/forms.html#attr-form-name">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-name-iframe>`name`</h4>
+<table aria-labelledby=att-name-iframe>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `name`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-name">`iframe`</a>;
+        <a data-cite="html/iframe-embed-object.html#attr-object-name">`object`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-name-map>`name`</h4>
+<table aria-labelledby=att-name-map>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `name`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/image-maps.html#attr-map-name">`map`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-name-meta>`name`</h4>
+<table aria-labelledby=att-name-meta>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `name`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-meta-name">`meta`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-name-slot>`name`</h4>
+<table aria-labelledby=att-name-slot>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `name`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/scripting.html#attr-slot-name">`slot`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-nomodule>`nomodule`</h4>
+<table aria-labelledby=att-nomodule>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `nomodule`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/scripting.html#attr-script-nomodule">`script`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-nonce>`nonce`</h4>
+<table aria-labelledby=att-nonce>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `nonce`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/urls-and-fetching.html#attr-nonce">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-novalidate>`novalidate`</h4>
+<table aria-labelledby=att-novalidate>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `novalidate`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-novalidate">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-open-details>`open`</h4>
+<table aria-labelledby=att-open-details>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `open`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interactive-elements.html#attr-details-open">`details`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaExpandedTrue">`aria-expanded`</a>="true | false"
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        `STATE_SYSTEM_EXPANDED`<br>`STATE_SYSTEM_COLLAPSED`
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <a href="https://msdn.microsoft.com/en-us/library/system.windows.automation.expandcollapsepattern.aspx">`ExpandCollapsePattern`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="states">
+          <span class="type">States: </span>
+          `ATK_STATE_COLLAPSED` or `ATK_STATE_EXPANDED` depending
+          on the attribute value
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXExpanded: YES|NO`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Set properties on the <a href="#el-summary">`summary`</a> element.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-open-dialog>`open`</h4>
+<table aria-labelledby=att-open-dialog>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `open`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interactive-elements.html#attr-dialog-open">`dialog`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">
+          If the `open` attribute is set via the `showModal()` method then <a class="core-mapping" href="#ariaModalTrue">`aria-modal="true"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+        </div>
+        <div class="general">
+          Otherwise, if the `open` attribute is set via the `show()` method, or explicitly specified by an author, then <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <p>
+          The `open` attribute's value is irrelevant. When the `open` attribute is not specified the default user agent styling for a `dialog` is `display: none`.
+        </p>
+        <p>
+          Authors can reveal a `dialog` through the style layer by modifying its `display` property. If revealed this way then the `dialog` is <a class="core-mapping" href="#ariaModalFalse">`aria-modal="false"`</a> and <a class="core-mapping" href="#ariaHiddenFalse">`aria-hidden="false"`</a>.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-optimum>`optimum`</h4>
+<table aria-labelledby=att-optimum>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `optimum`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-meter-optimum">`meter`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-pattern>`pattern`</h4>
+<table aria-labelledby=att-pattern>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `pattern`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-pattern">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">
+          If the value doesn't match the pattern: <a class="core-mapping" href="#ariaInvalidTrue">`aria-invalid="true"`</a>;
+          Otherwise, <a class="core-mapping" href="#ariaInvalidFalse">`aria-invalid="false"`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Use WAI-ARIA mapping
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-ping>`ping`</h4>
+<table aria-labelledby=att-ping>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `ping`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#ping">`a` and `area`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-placeholder>`placeholder`</h4>
+<table aria-labelledby=att-placeholder>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `placeholder`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-placeholder">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-textarea-placeholder">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaPlaceholder">`aria-placeholder`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">When the `placeholder` and `aria-placeholder` attributes are both present, and the `placeholder` attribute's value is non-empty, user agents MUST expose the value of the `placeholder` attribute, and ignore `aria-placeholder`. If the `placeholder` attribute's value is empty, then user agents MUST expose the value of the `aria-placeholder` attribute.</div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-playsinline>`playsinline`</h4>
+<table aria-labelledby=att-playsinline>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `playsinline`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-video-playsinline">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-poster>`poster`</h4>
+<table aria-labelledby=att-poster>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `poster`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-video-poster">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-preload>`preload`</h4>
+<table aria-labelledby=att-preload>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `preload`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-preload">`audio` and `video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-readonly>`readonly`</h4>
+<table aria-labelledby=att-readonly>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `readonly`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-readonly">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-textarea-readonly">`textarea`</a>;
+        <a data-cite="html/custom-elements.html#attr-face-readonly">form-associated custom elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaReadonlyTrue">`aria-readonly="true"`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element includes both the `readonly` attribute and the `aria-readonly` attribute with a valid value, User Agents MUST expose only the `readonly` attribute value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-referrerpolicy>`referrerpolicy`</h4>
+<table aria-labelledby=att-referrerpolicy>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `referrerpolicy`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-referrerpolicy">`a`</a>;
+        <a data-cite="html/links.html#attr-hyperlink-referrerpolicy">`area`</a>;
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-referrerpolicy">`iframe`</a>;
+        <a data-cite="html/embedded-content.html#attr-img-referrerpolicy">`img`</a>;
+        <a data-cite="html/semantics.html#attr-link-referrerpolicy">`link`</a>;
+        <a data-cite="html/scripting.html#attr-script-referrerpolicy">`script`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-rel>`rel`</h4>
+<table aria-labelledby=att-rel>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `rel`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-rel">`a`</a>;
+        <a data-cite="html/links.html#attr-hyperlink-rel">`area`</a>;
+        <a data-cite="html/semantics.html#attr-link-rel">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-required>`required`</h4>
+<table aria-labelledby=att-required>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `required`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-required">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-select-required">`select`</a>;
+        <a data-cite="html/form-elements.html#attr-textarea-required">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaRequiredTrue">`aria-required`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element includes both the `required` attribute and the `aria-required` attribute with a valid value, User Agents MUST expose only the `required` attribute value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-reversed>`reversed`</h4>
+<table aria-labelledby=att-reversed>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `reversed`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/grouping-content.html#attr-ol-reversed">`ol`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Reverses the numerical or alphabetical order of the child list item markers.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Reverses the numerical or alphabetical order of the child list item markers.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Reverses the numerical or alphabetical order of the child list item markers.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Reverses the numerical or alphabetical order of the child list item markers.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-rows>`rows`</h4>
+<table aria-labelledby=att-rows>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `rows`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-textarea-rows">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-rowspan>`rowspan`</h4>
+<table aria-labelledby=att-rowspan>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `rowspan`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/tables.html#attr-tdth-rowspan">`td`</a>;
+        <a data-cite="html/tables.html#attr-tdth-rowspan">`th`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaRowSpan">`aria-rowspan`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-sandbox>`sandbox`</h4>
+<table aria-labelledby=att-sandbox>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `sandbox`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-sandbox">`iframe`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-scope>`scope`</h4>
+<table aria-labelledby=att-scope>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `scope`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/tables.html#attr-th-scope">`th`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">
+          If `scope="row"` then map `th` to <a class="core-mapping" href="#role-map-columnheader">`rowheader`</a>
+        </div>
+        <div class="general">
+          If `scope="col"` then map `th` to <a class="core-mapping" href="#role-map-columnheader">`columnheader`</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-selected>`selected`</h4>
+<table aria-labelledby=att-selected>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `selected`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-option-selected">`option`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaSelectedTrue">`aria-selected="true"`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        If the element includes both the `selected` attribute and the `aria-selected` attribute with a valid value, User Agents MUST expose only the `selected` attribute value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-shape>`shape`</h4>
+<table aria-labelledby=att-shape>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `shape`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/image-maps.html#attr-area-shape">`area`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-size>`size`</h4>
+<table aria-labelledby=att-size>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `size`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-size">`input`</a>;
+        <a data-cite="html/form-elements.html#attr-select-size">`select`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">
+          Not mapped for `input` elements.
+        </div>
+        <div class="general">
+          If greater than 1, then creates a listbox accessible object. Refer to <a href="#el-select-listbox">`select`</a> element for details.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped for `input` elements.</div>
+        <div class="general">For `select` element use WAI-ARIA mapping.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped for `input` elements.</div>
+        <div class="general">For `select` element use WAI-ARIA mapping.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped for `input` elements.</div>
+        <div class="general">For `select` element use WAI-ARIA mapping.</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped for `input` elements.</div>
+        <div class="general">For `select` element use WAI-ARIA mapping.</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        For `input` elements that allow the `size` attribute, the attribute will modify their default width. A width provided by CSS will negate the effects of the `size` attribute on these `input` elements.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-sizes>`sizes`</h4>
+<table aria-labelledby=att-sizes>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `sizes`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-sizes">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-sizes-img-source>`sizes`</h4>
+<table aria-labelledby=att-sizes-img-source>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `sizes`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/embedded-content.html#attr-img-sizes">`img`</a>;
+        <a data-cite="html/embedded-content.html#attr-source-sizes">`source`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-slot>`slot`</h4>
+<table aria-labelledby=att-slot>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `slot`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#attr-slot">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-span>`span`</h4>
+<table aria-labelledby=att-span>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `span`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/tables.html#attr-col-span">`col`</a>;
+        <a data-cite="html/tables.html#attr-colgroup-span">`colgroup`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as `IAccessibleTableCell::columnExtent` on all cells at the column
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Exposed as `GridItem.ColumnSpan` on all cells at the column
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed via `atk_table_get_column_extent_at`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          `AXColumnIndexRange.length: &lt;value>`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-spellcheck>`spellcheck`</h4>
+<table aria-labelledby=att-spellcheck>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `spellcheck`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#attr-spellcheck">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaInvalidSpellingGrammar">`aria-invalid="spelling"` or `grammar`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-src-media>`src`</h4>
+<table aria-labelledby=att-src-media>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `src`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-media-src">`audio`</a>;
+        <a data-cite="html/iframe-embed-object.html#attr-embed-src">`embed`</a>;
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-src">`iframe`</a>;
+        <a data-cite="html/embedded-content.html#attr-img-src">`img`</a>;
+        <a data-cite="html/input.html#attr-input-src">`input`</a>;
+        <a data-cite="html/scripting.html#attr-script-src">`script`</a>;
+        <a data-cite="html/embedded-content.html#attr-source-src">`source` (in `audio` or `video`)</a>;
+        <a data-cite="html/media.html#attr-track-src">`track`</a>;
+        <a data-cite="html/media.html#attr-media-src">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span>
+          `src` on <a href="#el-img">`img`</a> only
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span>
+          `src` on <a href="#el-img">`img`</a> only
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXURL: &lt;value&gt;` on <a href="#el-img">`img`</a> and <a href="#el-input-image">`input type="image"`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-srcdoc>`srcdoc`</h4>
+<table aria-labelledby=att-srcdoc>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `srcdoc`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-iframe-srcdoc">`iframe`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-srclang>`srclang`</h4>
+<table aria-labelledby=att-srclang>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `srclang`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/media.html#attr-track-srclang">`track`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-srcset>`srcset`</h4>
+<table aria-labelledby=att-srcset>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `srcset`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/embedded-content.html#attr-img-srcset">`img`</a>;
+        <a data-cite="html/embedded-content.html#attr-source-srcset">`source`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not Mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-start>`start`</h4>
+<table aria-labelledby=att-start>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `start`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/grouping-content.html#attr-ol-start">`ol`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Changes the first number of the child list item accessible objects to match the `start` attribute's value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Changes the first number of the child list item accessible objects to match the `start` attribute's value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Changes the first number of the child list item accessible objects to match the `start` attribute's value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Changes the first number of the child list item accessible objects to match the `start` attribute's value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-step>`step`</h4>
+<table aria-labelledby=att-step>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `step`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-step">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        If the `input` is in the <a href="#el-input-range">`Range`</a> state, set both `RangeValue.SmallChange` and `RangeValue.LargeChange` to the value of `step`.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as `atk_value_get_minimum_increment` if the element implements the `AtkValue` interface.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-style>`style`</h4>
+<table aria-labelledby=att-style>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `style`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#the-style-attribute">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-tabindex>`tabindex`</h4>
+<table aria-labelledby=att-tabindex>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `tabindex`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/interaction.html#attr-tabindex">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#focus_state_event_table">See Focus States and Events Table</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-target>`target`</h4>
+<table aria-labelledby=att-target>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `target`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-target">`a`</a>;
+        <a data-cite="html/links.html#attr-hyperlink-target">`area`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-target-base>`target`</h4>
+<table aria-labelledby=att-target-base>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `target`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-base-target">`base`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-target-form>`target`</h4>
+<table aria-labelledby=att-target-form>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `target`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-control-infrastructure.html#attr-fs-target">`form`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-title>`title`</h4>
+<table aria-labelledby=att-title>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `title`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#attr-title">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">
+          Either the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>, or the
+          <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>, or Not mapped (see Comments).
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">
+          The <a href="#accessible-name-and-description-computation">Accessible Name and Description Computation</a> section specifies if the `title` attribute will be mapped and, if so, through what [[WAI-ARIA]] property.
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-title-abbr>`title`</h4>
+<table aria-labelledby=att-title-abbr>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `title`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/text-level-semantics.html#attr-abbr-title">`abbr`</a>;
+        <a data-cite="html/text-level-semantics.html#attr-dfn-title">`dfn`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="name">
+          Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="name">
+          Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="name">
+          Associates the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXExpandedTextValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-title-link>`title`</h4>
+<table aria-labelledby=att-title-link>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `title`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-title">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-title-style>`title`</h4>
+<table aria-labelledby=att-title-style>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `title`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/semantics.html#attr-link-title">`link`</a>; <a data-cite="html/semantics.html#attr-style-title">`style`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Provides the name for the CSS style sheet.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-translate>`translate`</h4>
+<table aria-labelledby=att-translate>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `translate`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/dom.html#attr-translate">HTML elements</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-type-hyperlink>`type`</h4>
+<table aria-labelledby=att-type-hyperlink>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `type`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/links.html#attr-hyperlink-type">`a`</a>;
+        <a data-cite="html/semantics.html#attr-link-type">`link`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-type-button>`type`</h4>
+<table aria-labelledby=att-type-button>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `type`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-button-type">`button`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          <a href="#el-input-submit">`submit`</a> type may be a default button in the form.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-type-embed>`type`</h4>
+<table aria-labelledby=att-type-embed>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `type`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/iframe-embed-object.html#attr-embed-type">`embed`</a>;
+        <a data-cite="html/iframe-embed-object.html#attr-object-type">`object`</a>;
+        <a data-cite="html/scripting.html#attr-script-type">`script`</a>;
+        <a data-cite="html/embedded-content.html#attr-source-type">`source`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-type-input>`type`</h4>
+<table aria-labelledby=att-type-input>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `type`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-type">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Refer to WAI-ARIA mappings for input types with defined ARIA roles.
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Defines the accessible role, states and other properties, refer to
+          type="<a href="#el-input-text">`text`</a>",
+          type="<a href="#el-input-password">`password`</a>",
+          type="<a href="#el-input-button">`button`</a>", etc
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Defines the accessible role, states and other properties, refer to
+          type="<a href="#el-input-text">`text`</a>",
+          type="<a href="#el-input-password">`password`</a>",
+          type="<a href="#el-input-button">`button`</a>", etc
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Defines the accessible role, states and other properties, refer to
+          type="<a href="#el-input-text">`text`</a>",
+          type="<a href="#el-input-password">`password`</a>",
+          type="<a href="#el-input-button">`button`</a>", etc
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Defines the accessible role, states and other properties, refer to
+          type="<a href="#el-input-text">`text`</a>",
+          type="<a href="#el-input-password">`password`</a>",
+          type="<a href="#el-input-button">`button`</a>", etc
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-type-ol>`type`</h4>
+<table aria-labelledby=att-type-ol>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `type`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/grouping-content.html#attr-ol-type">`ol`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
+        </div>
+        <div class="ifaces">
+          <span class="type">Interfaces:</span> `IAccessibleText2`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
+        </div>
+        <div class="ctrlpattern"><span class="type">Control Pattern:</span> `Text`</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Defines the list item marker, which has no <a class="termref">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
+        </div>
+        <div class="ifaces">
+          <span class="type">Interfaces:</span> `ATKText`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Defines the list item marker, which is exposed as content in `AXValue`, and rendered as an <a class="termref">accessible object</a>:</div>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXListMarker`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `"list marker"`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        <div class="general">Some platforms (IAccessible2, ATK, UIA) do not expose an <a class="termref">accessible object</a> for the list item marker, whether it was created and then pruned from the <a class="termref">accessibility tree</a>, or never created in the first place. Instead, they expose the list item marker as part of the associated list item's accessible text. In these cases, implementors need to consider such things as adjusting the offsets (e.g., for caret-moved events, text-selection events, etc.) for the updated list item text that now also contains the list item marker as content, rather than just taking the offsets unmodified from the list item renderer.</div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-usemap>`usemap`</h4>
+<table aria-labelledby=att-usemap>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `usemap`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/image-maps.html#attr-hyperlink-usemap">`img`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Responsible for image map creation.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Responsible for image map creation.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Responsible for image map creation.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          Responsible for image map creation.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        Refer to <a href="#el-img">`img`</a> element.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-value-button>`value`</h4>
+<table aria-labelledby=att-value-button>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `value`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-button-value">`button`</a>;
+        <a data-cite="html/form-elements.html#attr-option-value">`option`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-value-data>`value`</h4>
+<table aria-labelledby=att-value-data>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `value`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/text-level-semantics.html#attr-data-value">`data`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-value-input>`value`</h4>
+<table aria-labelledby=att-value-input>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `value`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-value">`input`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        Not mapped
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="name">
+          Associates the accessible value for entry type input elements
+          and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="name">
+          Associates the accessible value for entry type input elements
+          and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="name">
+          Associates the accessible value for entry type input elements
+          and <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXValue: &lt;value&gt;`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-value-li>`value`</h4>
+<table aria-labelledby=att-value-li>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `value`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/grouping-content.html#attr-li-value">`li`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as first text node of `li`'s accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Expose the value of the `value` attribute as the first text node in the list item.
+          If the value of the `value` attribute is an integer, set the UIA `PositionInSet` property to the integer value.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as first text node of `li`'s accessible object.
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Exposed as `AXValue: &lt;value&gt;` with accessible object:</div>
+        <div class="role">
+          <span class="type">AXRole:</span> `AXListMarker`
+        </div>
+        <div class="subrole">
+          <span class="type">AXSubrole:</span> `(nil)`
+        </div>
+        <div class="roledesc">
+          <span class="type">AXRoleDescription:</span> `list marker`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-value-meter>`value`</h4>
+<table aria-labelledby=att-value-meter>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `value`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-meter-value">`meter`</a>;
+        <a data-cite="html/form-elements.html#attr-progress-value">`progress`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#ariaValueNow">`aria-valuenow`</a>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Exposed as `IAccessibleValue::currentValue`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Exposed as `Value.Value`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Exposed as `atk_value_get_current_value`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">
+          `AXValue: &lt;value&gt;`
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-width>`width`</h4>
+<table aria-labelledby=att-width>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `width`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/canvas.html#attr-canvas-width">`canvas`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`embed`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`iframe`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`img`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`input`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`object`</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`source` (in `picture`)</a>;
+        <a data-cite="html/embedded-content-other.html#attr-dim-width">`video`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's width (`IAccessible::accLocation`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's width (`BoundingRectangle`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">
+          Defines an accessible object's width (`atk_component_get_size`)
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        `AXSize: w=<i>n</i>`
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-wrap>`wrap`</h4>
+<table aria-labelledby=att-wrap>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `wrap`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/form-elements.html#attr-textarea-wrap">`textarea`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
     </section>
   </section>
   <section class="normative">

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       edDraftURI:           "https://w3c.github.io/html-aam/",
       // lcEnd:  "2010-08-06",
 
-      maxTocLevel: 3,
+      maxTocLevel: 2,
 
       // editors
       editors:  [
@@ -39,7 +39,7 @@
 
       formerEditors: [
         { name: "Steve Faulkner", company: "TPGi", companyURL: "https://www.tpgi.com/", w3cid: 35007, note: "until May 2023" },
-		{ name: "Alexander Surkov", company: "Mozilla Foundation", companyURL: "https://www.mozilla.org/", w3cid: 51089, note: "until August 2018" },
+		    { name: "Alexander Surkov", company: "Mozilla Foundation", companyURL: "https://www.mozilla.org/", w3cid: 51089, note: "until August 2018" },
         { name: "Bogdan Brinza", company: "Microsoft", companyURL: "https://www.microsoft.com/", w3cid: 71139, note: "until July 2018" },
         { name: "Jason Kiss", company: "Invited Expert", w3cid: 50050, note: "until June 2018" },
         { name: "Cynthia Shelly", company: "Microsoft", companyURL: "https://www.microsoft.com/", w3cid: 11897, note: "until September 2013" }
@@ -646,10 +646,10 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
-      <td>
-      </td>
+      <td></td>
     </tr>
   </tbody>
 </table>
@@ -718,6 +718,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -764,6 +765,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -810,6 +812,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -857,6 +860,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -903,6 +907,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -950,6 +955,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -997,6 +1003,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1043,6 +1050,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1089,6 +1097,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1136,6 +1145,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1202,6 +1212,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1264,6 +1275,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1325,6 +1337,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1371,6 +1384,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1417,6 +1431,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1472,6 +1487,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1518,6 +1534,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1565,6 +1582,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1612,6 +1630,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1658,6 +1677,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1710,6 +1730,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1756,6 +1777,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1802,6 +1824,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1849,6 +1872,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1912,6 +1936,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -1958,6 +1983,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2004,6 +2030,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2059,6 +2086,7 @@
         Depends on format of data file
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2127,6 +2155,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2194,6 +2223,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2260,6 +2290,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2306,6 +2337,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2360,6 +2392,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2412,6 +2445,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2460,6 +2494,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2506,6 +2541,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2552,6 +2588,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2598,6 +2635,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2651,6 +2689,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2699,6 +2738,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2748,6 +2788,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2794,6 +2835,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2840,6 +2882,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2901,6 +2944,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2947,6 +2991,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -2997,6 +3042,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3044,6 +3090,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3095,6 +3142,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3162,6 +3210,7 @@
         <div class="roledesc"><span class="type">AXRoleDescription:</span> `"color well"`</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3234,6 +3283,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3296,6 +3346,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3347,6 +3398,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3429,6 +3481,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3477,6 +3530,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3525,6 +3579,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3587,6 +3642,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3660,6 +3716,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3730,6 +3787,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3783,6 +3841,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3831,6 +3890,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3879,6 +3939,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3927,6 +3988,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -3977,6 +4039,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4034,6 +4097,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4085,6 +4149,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4148,6 +4213,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4218,6 +4284,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4270,6 +4337,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4337,6 +4405,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4383,6 +4452,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4444,6 +4514,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4528,6 +4599,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4600,6 +4672,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4650,6 +4723,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4698,6 +4772,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4744,6 +4819,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4804,6 +4880,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4850,6 +4927,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4896,6 +4974,7 @@
         See comments
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4943,6 +5022,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -4998,6 +5078,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5044,6 +5125,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5090,6 +5172,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5136,6 +5219,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5195,6 +5279,7 @@
         Depends on format of data file.
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5241,6 +5326,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5287,6 +5373,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5333,6 +5420,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5385,6 +5473,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5437,6 +5526,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5483,6 +5573,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5530,6 +5621,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5576,6 +5668,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5622,6 +5715,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5668,6 +5762,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5723,6 +5818,7 @@
         Not mapped
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5784,6 +5880,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5847,6 +5944,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5893,6 +5991,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5939,6 +6038,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -5985,6 +6085,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6031,6 +6132,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6078,6 +6180,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6128,6 +6231,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6178,6 +6282,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6224,6 +6329,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6270,6 +6376,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6317,6 +6424,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6363,6 +6471,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6409,6 +6518,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6455,6 +6565,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6506,6 +6617,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6579,6 +6691,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6627,6 +6740,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6673,6 +6787,7 @@
         See comments
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6721,6 +6836,7 @@
         Use WAI-ARIA mapping
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6767,6 +6883,7 @@
         Use WAI-ARIA mapping
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6815,6 +6932,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6864,6 +6982,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6910,6 +7029,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -6957,6 +7077,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7003,6 +7124,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7057,6 +7179,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7112,6 +7235,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7159,6 +7283,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7206,6 +7331,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7252,6 +7378,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7298,6 +7425,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7344,6 +7472,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7391,6 +7520,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7437,6 +7567,7 @@
         <div class="general">Not mapped</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7483,6 +7614,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7530,6 +7662,7 @@
         <div class="general">Use WAI-ARIA mapping</div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7585,6 +7718,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7653,6 +7787,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -7711,6 +7846,7 @@
         </div>
       </td>
     </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
     <tr>
       <th>Comments</th>
       <td>
@@ -16453,6 +16589,125 @@
       </ol>
     </section>
   </section>
+
+
+  <!-- obsolete features 
+    <tr tabindex="-1" id="el-rb">
+        <th>
+          <a href="https://html.spec.whatwg.org/#rb">`rb`</a>
+        </th>
+        <td class="aria">No corresponding role</td>
+        <td class="role-computed"><div class="general">html-rb</div></td>
+        <td class="ia2">
+          <div class="role">
+            <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+          </div>
+        </td>
+        <td class="uia">
+          <div class="ctrltype">
+            <span class="type">Control Type:</span> `Text`
+          </div>
+        </td>
+        <td class="atk">
+          <div class="role">
+            <span class="type">Role:</span> `ATK_ROLE_STATIC`
+          </div>
+        </td>
+        <td class="ax">
+          <div class="role">
+            <span class="type">AXRole:</span> `AXGroup`
+          </div>
+          <div class="subrole">
+            <span class="type">AXSubrole:</span> `AXRubyBase`
+          </div>
+          <div class="roledesc">
+            <span class="type">AXRoleDescription:</span> `"group"`
+          </div>
+        </td>
+        <td class="naming"></td>
+        <td class="comments"><a href="https://html.spec.whatwg.org/#rb">Marked as Obsolete in HTML</a>.</td>
+      </tr>
+      <tr tabindex="-1" id="el-rtc">
+                <th>
+                  <a href="https://html.spec.whatwg.org/#rtc">`rtc`</a>
+                </th>
+                <td class="aria">No corresponding role</td>
+                <td class="role-computed"><div class="general">html-rtc</div></td>
+                <td class="ia2">
+                  <div class="role">
+                    <span class="type">Role:</span> `ROLE_SYSTEM_TEXT`; `IA2_ROLE_TEXT_FRAME`
+                  </div>
+                </td>
+                <td class="uia">
+                  <div class="ctrltype">
+                    <span class="type">Control Type:</span> `Text`
+                  </div>
+                </td>
+                <td class="atk">
+                  <div class="role">
+                    <span class="type">Role:</span> `ATK_ROLE_STATIC`
+                  </div>
+                </td>
+                <td class="ax">
+                  <div class="role">
+                    <span class="type">AXRole:</span> `AXGroup`
+                  </div>
+                  <div class="subrole">
+                    <span class="type">AXSubrole:</span> `AXRubyBase`
+                  </div>
+                  <div class="roledesc">
+                    <span class="type">AXRoleDescription:</span> `"group"`
+                  </div>
+                </td>
+                <td class="naming"></td>
+                <td class="comments">
+                  <a href="https://html.spec.whatwg.org/#rtc">Marked as Obsolete in HTML</a>.</td>
+              </tr>
+
+              <tr tabindex="-1" id="att-name-param">
+              <th>`name`</th>
+              <td class="elements">
+                <a data-cite="html/iframe-embed-object.html#attr-param-name">`param`</a>
+              </td>
+              <td class="aria"><div class="general">Not mapped</div></td>
+              <td class="ia2"><div class="general">Not mapped</div></td>
+              <td class="uia"><div class="general">Not mapped</div></td>
+              <td class="atk"><div class="general">Not mapped</div></td>
+              <td class="ax"><div class="general">Not mapped</div></td>
+              <td class="comments"></td>
+            </tr> 
+         
+
+         other obsolete HTML elements
+         applet
+         acronym - https://html.spec.whatwg.org/multipage/obsolete.html#other-elements,-attributes-and-apis
+         bgsound
+         dir
+         frame, frameset, noframes
+         inindex
+         keygen
+         listing
+         menuitem
+         nextid
+         noembed
+         plaintext
+         strike
+         xmp
+         basefont
+         big
+         blink
+         center
+         font
+         marquee
+         multicol
+         nobr
+         spacer
+         tt
+
+         marquee - https://html.spec.whatwg.org/multipage/obsolete.html#the-marquee-element
+         frameset - https://html.spec.whatwg.org/multipage/obsolete.html#frames
+
+  -->
   <section>
 		<h2>Privacy considerations</h2>
 		<p>


### PR DESCRIPTION
Githack link, as PR Preview doesn't include styles: https://raw.githack.com/w3c/html-aam/remove-tables/index.html

same work as: https://github.com/w3c/core-aam/pull/180

@scottaohara -- there are a few "commented out" sections of the html, for example:
- https://github.com/w3c/html-aam/blob/903e1ecc5e032677c4222a318721934694624215/index.html#L2603
- https://github.com/w3c/html-aam/blob/903e1ecc5e032677c4222a318721934694624215/index.html#L2701

These changes don't carry those "commented out" things through -- do you want to keep them around?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/500.html" title="Last updated on Aug 25, 2023, 8:37 PM UTC (63372b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/500/903e1ec...63372b0.html" title="Last updated on Aug 25, 2023, 8:37 PM UTC (63372b0)">Diff</a>