### PR TITLE
[Editorial] Add spaces between element name and bracket in headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
           </ul>
         </li>
       </ul>
-<h4 id=el-a>`a`<span class="el-context">(represents a hyperlink)</span></h4>
+<h4 id=el-a>`a` <span class="el-context">(represents a hyperlink)</span></h4>
 <table aria-labelledby=el-a>
   <tbody>
     <tr>
@@ -258,7 +258,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-a-no-href>`a`<span class="el-context">(no `href` attribute)</span></h4>
+<h4 id=el-a-no-href>`a` <span class="el-context">(no `href` attribute)</span></h4>
 <table aria-labelledby=el-a-no-href>
   <tbody>
     <tr>
@@ -419,7 +419,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-area>`area`<span class="el-context">(represents a hyperlink)</span></h4>
+<h4 id=el-area>`area` <span class="el-context">(represents a hyperlink)</span></h4>
 <table aria-labelledby=el-area>
   <tbody>
     <tr>
@@ -466,7 +466,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-area-no-href>`area`<span class="el-context">(no `href` attribute)</span></h4>
+<h4 id=el-area-no-href>`area` <span class="el-context">(no `href` attribute)</span></h4>
 <table aria-labelledby=el-area-no-href>
   <tbody>
     <tr>
@@ -2999,7 +2999,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-img-empty-alt>`img`<span class="el-context">(`alt`attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span></h4>
+<h4 id=el-img-empty-alt>`img` <span class="el-context">(`alt`attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span></h4>
 <table aria-labelledby=el-img-empty-alt>
   <tbody>
     <tr>
@@ -3098,7 +3098,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-checkbox>`input`<span class="el-context">(`type` attribute in the  Checkbox state)</span></h4>
+<h4 id=el-input-checkbox>`input` <span class="el-context">(`type` attribute in the  Checkbox state)</span></h4>
 <table aria-labelledby=el-input-checkbox>
   <tbody>
     <tr>
@@ -3291,7 +3291,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-datetime-local>`input`<span class="el-context">(`type` attribute in theLocal Date and Time state)</span></h4>
+<h4 id=el-input-datetime-local>`input` <span class="el-context">(`type` attribute in theLocal Date and Time state)</span></h4>
 <table aria-labelledby=el-input-datetime-local>
   <tbody>
     <tr>
@@ -3489,7 +3489,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-hidden>`input`<span class="el-context">(`type` attribute in the  Hidden state)</span></h4>
+<h4 id=el-input-hidden>`input` <span class="el-context">(`type` attribute in the  Hidden state)</span></h4>
 <table aria-labelledby=el-input-hidden>
   <tbody>
     <tr>
@@ -3538,7 +3538,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-image>`input`<span class="el-context">(`type` attribute in the  Image Button state)</span></h4>
+<h4 id=el-input-image>`input` <span class="el-context">(`type` attribute in the  Image Button state)</span></h4>
 <table aria-labelledby=el-input-image>
   <tbody>
     <tr>
@@ -3587,7 +3587,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-month>`input`<span class="el-context">(`type` attribute in the  Month state)</span></h4>
+<h4 id=el-input-month>`input` <span class="el-context">(`type` attribute in the  Month state)</span></h4>
 <table aria-labelledby=el-input-month>
   <tbody>
     <tr>
@@ -3650,7 +3650,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-number>`input`<span class="el-context">(`type` attribute in the  Number state)</span></h4>
+<h4 id=el-input-number>`input` <span class="el-context">(`type` attribute in the  Number state)</span></h4>
 <table aria-labelledby=el-input-number>
   <tbody>
     <tr>
@@ -3724,7 +3724,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-password>`input`<span class="el-context">(`type` attribute in the  Password state)</span></h4>
+<h4 id=el-input-password>`input` <span class="el-context">(`type` attribute in the  Password state)</span></h4>
 <table aria-labelledby=el-input-password>
   <tbody>
     <tr>
@@ -3795,7 +3795,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-radio>`input`<span class="el-context">(`type` attribute in the  Radio Button state)</span></h4>
+<h4 id=el-input-radio>`input` <span class="el-context">(`type` attribute in the  Radio Button state)</span></h4>
 <table aria-labelledby=el-input-radio>
   <tbody>
     <tr>
@@ -3849,7 +3849,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-range>`input`<span class="el-context">(`type` attribute in the  Range state)</span></h4>
+<h4 id=el-input-range>`input` <span class="el-context">(`type` attribute in the  Range state)</span></h4>
 <table aria-labelledby=el-input-range>
   <tbody>
     <tr>
@@ -3898,7 +3898,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-reset>`input`<span class="el-context">(`type` attribute in the  Reset Button state)</span></h4>
+<h4 id=el-input-reset>`input` <span class="el-context">(`type` attribute in the  Reset Button state)</span></h4>
 <table aria-labelledby=el-input-reset>
   <tbody>
     <tr>
@@ -3947,7 +3947,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-search>`input`<span class="el-context">(`type` attribute in the  Search state with no suggestions source element)</span></h4>
+<h4 id=el-input-search>`input` <span class="el-context">(`type` attribute in the  Search state with no suggestions source element)</span></h4>
 <table aria-labelledby=el-input-search>
   <tbody>
     <tr>
@@ -4221,7 +4221,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-time>`input`<span class="el-context">(`type` attribute in the  Time state)</span></h4>
+<h4 id=el-input-time>`input` <span class="el-context">(`type` attribute in the  Time state)</span></h4>
 <table aria-labelledby=el-input-time>
   <tbody>
     <tr>
@@ -4292,7 +4292,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-input-url>`input`<span class="el-context">(`type` attribute in the  URL state with no suggestions source element)</span></h4>
+<h4 id=el-input-url>`input` <span class="el-context">(`type` attribute in the  URL state with no suggestions source element)</span></h4>
 <table aria-labelledby=el-input-url>
   <tbody>
     <tr>
@@ -7132,7 +7132,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-th>`th`<span class="el-context">(is not a  column header,  row header,  column group header or  row group header,  and ancestor `table` element has  `table` role)</span></h4>
+<h4 id=el-th>`th` <span class="el-context">(is not a  column header,  row header,  column group header or  row group header,  and ancestor `table` element has  `table` role)</span></h4>
 <table aria-labelledby=el-th>
   <tbody>
     <tr>
@@ -7187,7 +7187,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-th-gridcell>`th`<span class="el-context">(is not a  column header,  row header,  column group header or  row group header,  and ancestor `table` element has  `grid`  or `treegrid` role)</span></h4>
+<h4 id=el-th-gridcell>`th` <span class="el-context">(is not a  column header,  row header,  column group header or  row group header,  and ancestor `table` element has  `grid`  or `treegrid` role)</span></h4>
 <table aria-labelledby=el-th-gridcell>
   <tbody>
     <tr>
@@ -7243,7 +7243,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-th-columnheader>`th`<span class="el-context">(is a column header or column group header)</span></h4>
+<h4 id=el-th-columnheader>`th` <span class="el-context">(is a column header or column group header)</span></h4>
 <table aria-labelledby=el-th-columnheader>
   <tbody>
     <tr>
@@ -7291,7 +7291,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-th-rowheader>`th`<span class="el-context">(is a row header or row group header)</span></h4>
+<h4 id=el-th-rowheader>`th` <span class="el-context">(is a row header or row group header)</span></h4>
 <table aria-labelledby=el-th-rowheader>
   <tbody>
     <tr>


### PR DESCRIPTION
On a few headings ([example](https://w3c.github.io/html-aam/#el-a)) there is no space between the element name and bracket, this fixes that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/YummyBacon5/html-aam/pull/503.html" title="Last updated on Sep 25, 2023, 10:33 AM UTC (f5e8a33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/503/f16d875...YummyBacon5:f5e8a33.html" title="Last updated on Sep 25, 2023, 10:33 AM UTC (f5e8a33)">Diff</a>