### PR TITLE
Update: hr within select element

### DIFF
--- a/index.html
+++ b/index.html
@@ -16748,6 +16748,7 @@
       <section>
         <h4>Substantive changes since moving to the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications Working Group</a> (03-Nov-2019)</h4>
         <ul>
+          <li>09-Oct-2023: Acknowledge use of `hr` element within `select` element. See <a href="https://github.com/w3c/html-aam/pull/504">GitHub PR 504</a>.</li>
           <li>03-Oct-2023: Update image mappings to reference the primary synonym roles (`image` and `none`). See <a href="https://github.com/w3c/html-aam/pull/498">GitHub PR 498</a>.</li>
           <li>03-Oct-2023: Clarify when to expose required field as invalid. See <a href="https://github.com/w3c/html-aam/pull/429">GitHub PR 429</a>.</li>
           <li>06-Jun-2023: Add computed roles for all HTML elements. See <a href="https://github.com/w3c/html-aam/pull/465">GitHub PR 465</a>.</li>

--- a/index.html
+++ b/index.html
@@ -2792,6 +2792,7 @@
     <tr>
       <th>Comments</th>
       <td>
+        <p>If an `hr` element is a descendant of a `select` element, user agents MAY expose the element with a role of `none`.</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
closes #480 

Outside of browsers / AT significantly changing how people interact with the UA-provided listboxs, I don't see how the use of hr can be more than declarative decoration, since the element will not be directly accessible to anyone using AT.

If anyone thinks otherwise, and browsers/AT are willing to make changes to how this component has been behaving/exposed, we can discuss and change the PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/504.html" title="Last updated on Oct 9, 2023, 7:20 PM UTC (656f7da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/504/ad9cb13...656f7da.html" title="Last updated on Oct 9, 2023, 7:20 PM UTC (656f7da)">Diff</a>