### PR TITLE
reference name/desc

### DIFF
--- a/index.html
+++ b/index.html
@@ -16308,7 +16308,7 @@
     <p>The terms <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> and <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> are properties provided in all <a class="termref">accessibility APIs</a>. The name of the properties may differ across APIs but they serve the same function: as a container for a short (name) or longer (description) string of text.</p>
     <p>The <a href="#mapping_additional_nd_te" class="accname">text alternative computation</a> is used to generate both the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> and <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>. There are different rules provided for several different types of <a class="termref" data-lt="element">elements</a>, <a class="termref" data-lt="node">nodes</a>, and combinations of markup.</p>
     <p class="note">
-      User Agents can inform assistive technology if an element's accessible name, description, or both dynamically updates per the specified 
+      User Agents notify assistive technology when relevant accessibility information changes, sometimes by destroying and recreating the accessibility object, or sometimes by notifying of changes to the object per the specified 
       <a data-cite="core-aam-1.2/#event-aria-label">name change event mappings</a> and <a data-cite="core-aam-1.2/#event-aria-describedby">description change event mappings</a>.
     </p>
     <section id="accname-computation">

--- a/index.html
+++ b/index.html
@@ -16307,6 +16307,10 @@
     <h2>Accessible Name and Description Computation</h2>
     <p>The terms <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> and <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a> are properties provided in all <a class="termref">accessibility APIs</a>. The name of the properties may differ across APIs but they serve the same function: as a container for a short (name) or longer (description) string of text.</p>
     <p>The <a href="#mapping_additional_nd_te" class="accname">text alternative computation</a> is used to generate both the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> and <a data-cite="accname-1.2/#dfn-accessible-description">accessible description</a>. There are different rules provided for several different types of <a class="termref" data-lt="element">elements</a>, <a class="termref" data-lt="node">nodes</a>, and combinations of markup.</p>
+    <p class="note">
+      User Agents can inform assistive technology if an element's accessible name, description, or both dynamically updates per the specified 
+      <a data-cite="core-aam-1.2/#event-aria-label">name change event mappings</a> and <a data-cite="core-aam-1.2/#event-aria-describedby">description change event mappings</a>.
+    </p>
     <section id="accname-computation">
       <h3>Accessible Name Computations By HTML Element</h3>
       <section>
@@ -16606,7 +16610,6 @@
       </ol>
     </section>
   </section>
-
 
   <!-- obsolete features 
     <tr tabindex="-1" id="el-rb">


### PR DESCRIPTION
closes #291 

adding note to reference the already specified name/desc change events in core aam.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/507.html" title="Last updated on Oct 13, 2023, 11:16 AM UTC (7bc77e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/507/5856839...7bc77e0.html" title="Last updated on Oct 13, 2023, 11:16 AM UTC (7bc77e0)">Diff</a>