### PR TITLE
reduce TOC

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       edDraftURI:           "https://w3c.github.io/html-aam/",
       // lcEnd:  "2010-08-06",
 
-      maxTocLevel: 3,
+      maxTocLevel: 2,
 
       // editors
       editors:  [


### PR DESCRIPTION
closes #502

the TOC including all of the HTML elements/attributes makes initial load of the doc take a very long time - and it does make the TOC rather unusable when it contains around 200ish items in it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/508.html" title="Last updated on Oct 9, 2023, 1:55 PM UTC (66ab673)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/508/5856839...66ab673.html" title="Last updated on Oct 9, 2023, 1:55 PM UTC (66ab673)">Diff</a>