### PR TITLE
switch attribute for checkbox inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -15085,7 +15085,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=att-switch>`style`</h4>
+<h4 id=att-style>`style`</h4>
 <table aria-labelledby=att-style>
   <tbody>
     <tr>

--- a/index.html
+++ b/index.html
@@ -3157,6 +3157,58 @@
     </tr>
   </tbody>
 </table>
+<h4 id=el-input-checkbox-switch>`input` <span class="el-context">(`type` attribute in the Checkbox state)</span> with the <code>switch</code> attribute</h4>
+<table aria-labelledby=el-input-checkbox-switch>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="html">`input`</a>
+        <span class="el-context">(<a data-cite="html/input.html#attr-input-type">`type`</a> attribute in the
+        <a data-cite="html/input.html#checkbox-state-(type=checkbox)">Checkbox</a> state)</span> with the
+        <a data-cite="html/input.html#attr-input-switch">`switch`</a> attribute
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-checkbox">`switch`</a> role, with the
+        <a class="core-mapping" href="#ariaCheckedMixed">`aria-checked`</a> state set to "true" if the element's
+        <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> is true, or "false" otherwise
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+    <tr>
+      <th>Comments</th>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <h4 id=el-input-color>`input` <span class="el-context">(`type` attribute in theColor state)</span></h4>
 <table aria-labelledby=el-input-color>
   <tbody>
@@ -14979,7 +15031,61 @@
     </tr>
   </tbody>
 </table>
-<h4 id=att-style>`style`</h4>
+<h4 id=att-switch>`switch`</h4>
+<table aria-labelledby=att-switch>
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        `switch`
+      </td>
+    </tr>
+    <tr>
+      <th>Element(s)</th>
+      <td>
+        <a data-cite="html/input.html#attr-input-checked">`input`</a> `type=checkbox`
+      </td>
+    </tr>
+    <tr>
+      <th>[[WAI-ARIA-1.2]]</th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Not mapped</div>
+      </td>
+    </tr>
+    <tr>
+      <th>Comments</th>
+      <td>
+        The `switch` attribute modifies the semantics and behavior of the `input` element in the checkbox state.
+        See <a href="#el-input-checkbox-switch">`input type=checkbox switch`</a> for mapping details.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=att-switch>`style`</h4>
 <table aria-labelledby=att-style>
   <tbody>
     <tr>


### PR DESCRIPTION
closes #496 if this feature goes through.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 18, 2023, 12:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fhtml-aam%2F326ce09e264057f4e560e17efaa2a725c5f40cf2%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/FD9Dh7/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-10-18
ReSpec version: 34.2.0
File a bug: https://github.com/w3c/respec/
Error: undefined

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aam%23510.)._
</details>
