### PR TITLE
[Editorial] Add spaces between code markup and words

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,7 +605,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-aside>`aside`(scoped to a sectioning content element)</h4>
+<h4 id=el-aside>`aside` (scoped to a sectioning content element)</h4>
 <table aria-labelledby=el-aside>
   <tbody>
     <tr>
@@ -1542,7 +1542,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-datalist>`datalist`(represents pre-defined options for `input` element)</h4>
+<h4 id=el-datalist>`datalist` (represents pre-defined options for `input` element)</h4>
 <table aria-labelledby=el-datalist>
   <tbody>
     <tr>
@@ -3005,7 +3005,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-img-empty-alt>`img` <span class="el-context">(`alt`attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span></h4>
+<h4 id=el-img-empty-alt>`img` <span class="el-context">(`alt` attribute value is an empty string, i.e. `alt=""` or `alt` with no value in the markup)</span></h4>
 <table aria-labelledby=el-img-empty-alt>
   <tbody>
     <tr>
@@ -6898,7 +6898,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-td>`td`(ancestor `table` element has`table` role)</h4>
+<h4 id=el-td>`td` (ancestor `table` element has `table` role)</h4>
 <table aria-labelledby=el-td>
   <tbody>
     <tr>
@@ -6947,7 +6947,7 @@
     </tr>
   </tbody>
 </table>
-<h4 id=el-td-gridcell>`td`(ancestor `table` element has`grid` or`treegrid` role)</h4>
+<h4 id=el-td-gridcell>`td` (ancestor `table` element has `grid` or `treegrid` role)</h4>
 <table aria-labelledby=el-td-gridcell>
   <tbody>
     <tr>
@@ -11472,7 +11472,7 @@
     <tr>
       <th>Comments</th>
       <td>
-        If the element has the `indeterminate [IDL]` set and the `aria-checked` attribute set, User Agents MUST expose only the`indeterminate [IDL]` state.
+        If the element has the `indeterminate [IDL]` set and the `aria-checked` attribute set, User Agents MUST expose only the `indeterminate [IDL]` state.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
In many places, there is no space between words and code markup


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/YummyBacon5/html-aam/pull/513.html" title="Last updated on Nov 1, 2023, 11:31 PM UTC (4095b99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/513/d21836c...YummyBacon5:4095b99.html" title="Last updated on Nov 1, 2023, 11:31 PM UTC (4095b99)">Diff</a>