### PR TITLE
Chore: editorial spec cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
   <section id="intro" class="informative">
     <h2>Introduction</h2>
     <p>
-      This specification defines how HTML user agents respond to and expose [=role=], [=state=] and [=ARIA/property=] information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default [[[wai-aria]]] semantics must be exposed to the platform <a class="termref">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the [[[core-aam-1.2]]] ([[core-aam-1.2]]) specification.
+      This specification defines how HTML user agents respond to and expose [=role=], [=state=] and [=ARIA/property=] information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default [[[wai-aria-1.2]]] semantics must be exposed to the platform <a class="termref">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the [[[core-aam-1.2]]] ([[core-aam-1.2]]) specification.
     </p>
     <p>
       In some cases, often due to features of the HTML host language or the accessibility API in question, an element or attribute's mapping differs from the corresponding ARIA mappings specified in the [[core-aam-1.2]]. Where an HTML element or attribute does not have any default WAI-ARIA semantics, the applicable mapping for each platform <a class="termref">accessibility API</a> is defined by this specification.

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
   <section id="intro" class="informative">
     <h2>Introduction</h2>
     <p>
-      This specification defines how HTML user agents respond to and expose [=role=], [=state=] and [=ARIA/property=] information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default [[[wai-aria-1.2]]] semantics must be exposed to the platform <a class="termref">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the [[[core-aam-1.2]]] ([[core-aam-1.2]]) specification.
+      This specification defines how HTML user agents respond to and expose [=role=], [=state=] and [=ARIA/property=] information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default [[[wai-aria-1.2]]] semantics must be exposed to the platform <a class="termref">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the [[[core-aam-1.2]]] specification.
     </p>
     <p>
       In some cases, often due to features of the HTML host language or the accessibility API in question, an element or attribute's mapping differs from the corresponding ARIA mappings specified in the [[core-aam-1.2]]. Where an HTML element or attribute does not have any default WAI-ARIA semantics, the applicable mapping for each platform <a class="termref">accessibility API</a> is defined by this specification.
@@ -116,7 +116,7 @@
       <li>[[[core-aam-1.2]]]</li>
       <li>HTML Accessibility API Mappings 1.0 (this specification)</li>
       <!-- mathml aam link needs a shortcode, this doesn't appear to exit right now -->
-      <li><cite><a href="https://w3c.github.io/mathml-aam/">MathML AAM 1.0</a></cite></li>
+      <li><cite><a href="https://w3c.github.io/mathml-aam/">MathML Accessibility API Mappings 1.0</a></cite></li>
       <li>[[[svg-aam-1.0]]]</li>
     </ul>
     <section id="intro_aapi">
@@ -125,13 +125,13 @@
         <a class="termref">Accessibility APIs</a> covered by this document are:
       </p>
       <ul>
-        <li><abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite><a href="https://wiki.linuxfoundation.org/accessibility/iaccessible2/start">IAccessible2 1.3</a></cite> [[IAccessible2]]</li>
-        <li><cite><a href="https://msdn.microsoft.com/en-us/library/ee684013%28VS.85%29.aspx">User Interface Automation</a></cite> [[UI-AUTOMATION]]</li>
-        <li><cite>Linux/GNOME <a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK - Accessibility Toolkit</a></cite> [[ATK]] and <cite><a href="https://gitlab.gnome.org/GNOME/at-spi2-core/">Assistive Technology Service Provider Interface</a></cite> [[AT-SPI]], referred to hereafter as "ATK/AT-SPI"</li>
-        <li><cite><a href="https://developer.apple.com/reference/appkit/nsaccessibility">Mac OS X Accessibility Protocol Mac OS 10.10</a></cite> [[AXAPI]]</li>
+        <li><abbr title="Microsoft Active Accessibility">MSAA</abbr> with <cite>IAccessible2 1.3</cite> [[IAccessible2]]</li>
+        <li><cite>User Interface Automation</cite> [[UI-AUTOMATION]]</li>
+	      <li><cite>ATK - Accessibility Toolkit</cite> [[ATK]] and <cite>Assistive Technology Service Provider Interface</cite> [[AT-SPI]], referred to hereafter as "ATK/AT-SPI"</li>
+	      <li><cite>macOS Accessibility Protocol</cite> [[AXAPI]]</li>
       </ul>
       <p>
-        If user agent developers need to expose information using other <a class="termref">accessibility APIs</a>, it is recommended that they work closely with the developer of the platform where the API runs, and assistive technology developers on that platform.
+        If user agent developers need to expose information using other <a class="termref">accessibility APIs</a>, it is recommended that they work closely with the developer of the platform where the <abbr title="application programming interface">API</abbr> runs, and assistive technology developers on that platform.
       </p>
       <p>
         For more information regarding <a class="termref">accessibility APIs</a>, refer to <a data-cite="core-aam-1.2/#intro_aapi">section 1.1 Accessibility APIs</a> of the [[[core-aam-1.2]]].

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 <body>
   <section id="abstract">
     <p>
-      HTML Accessibility API Mappings (HTML-AAM) defines how <a class="termref">user agents</a> map <abbr title="HyperText Markup Language">HTML</abbr> [[HTML]] elements and attributes to platform <a class="termref" data-lt="accessibility API">accessibility application programming interfaces (<abbr title="Application Programming Interfaces">APIs</abbr>)</a>. It leverages and extends the [[[core-aam-1.2]]] and the [[[accname-aam-1.2]]] for use with the HTML host language. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent.
+      HTML Accessibility API Mappings (HTML-AAM) defines how <a class="termref">user agents</a> map <abbr title="HyperText Markup Language">HTML</abbr> [[HTML]] elements and attributes to platform <a class="termref" data-lt="accessibility API">accessibility application programming interfaces (<abbr title="Application Programming Interfaces">APIs</abbr>)</a>. It leverages and extends the [[[core-aam-1.2]]] and the [[[accname-1.2]]] for use with the HTML host language. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent.
     </p>
     <p>
       The HTML-AAM is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite described in the <a href="https://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Overview</a>.

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 <body>
   <section id="abstract">
     <p>
-      HTML Accessibility API Mappings (HTML-AAM) defines how <a class="termref">user agents</a> map <abbr title="HyperText Markup Language">HTML</abbr> [[HTML]] elements and attributes to platform <a class="termref" data-lt="accessibility API">accessibility application programming interfaces (<abbr title="Application Programming Interfaces">APIs</abbr>)</a>. It leverages and extends the [[[core-aam-1.2]]] and the [[[accname-aam-1.1]]] for use with the HTML host language. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent.
+      HTML Accessibility API Mappings (HTML-AAM) defines how <a class="termref">user agents</a> map <abbr title="HyperText Markup Language">HTML</abbr> [[HTML]] elements and attributes to platform <a class="termref" data-lt="accessibility API">accessibility application programming interfaces (<abbr title="Application Programming Interfaces">APIs</abbr>)</a>. It leverages and extends the [[[core-aam-1.2]]] and the [[[accname-aam-1.2]]] for use with the HTML host language. Documenting these mappings promotes interoperable exposure of roles, states, properties, and events implemented by accessibility APIs and helps to ensure that this information appears in a manner consistent with author intent.
     </p>
     <p>
       The HTML-AAM is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite described in the <a href="https://www.w3.org/WAI/intro/aria.php"><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Overview</a>.
@@ -100,7 +100,7 @@
   <section id="intro" class="informative">
     <h2>Introduction</h2>
     <p>
-      This specification defines how HTML user agents respond to and expose [=role=], [=state=] and [=ARIA/property=] information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default [[[WAI-ARIA]]] semantics must be exposed to the platform <a class="termref">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the [[[core-aam-1.2]]] ([[core-aam-1.2]]) specification.
+      This specification defines how HTML user agents respond to and expose [=role=], [=state=] and [=ARIA/property=] information provided for Web content. Unless indicated otherwise, an HTML element or attribute with default [[[wai-aria]]] semantics must be exposed to the platform <a class="termref">accessibility APIs</a> according to the relevant WAI-ARIA mappings defined in the [[[core-aam-1.2]]] ([[core-aam-1.2]]) specification.
     </p>
     <p>
       In some cases, often due to features of the HTML host language or the accessibility API in question, an element or attribute's mapping differs from the corresponding ARIA mappings specified in the [[core-aam-1.2]]. Where an HTML element or attribute does not have any default WAI-ARIA semantics, the applicable mapping for each platform <a class="termref">accessibility API</a> is defined by this specification.
@@ -115,9 +115,9 @@
       <li>[[[accname-1.2]]]</li>
       <li>[[[core-aam-1.2]]]</li>
       <li>HTML Accessibility API Mappings 1.0 (this specification)</li>
-      <li>[[[svg-aam-1.0]]]</li>
       <!-- mathml aam link needs a shortcode, this doesn't appear to exit right now -->
       <li><cite><a href="https://w3c.github.io/mathml-aam/">MathML AAM 1.0</a></cite></li>
+      <li>[[[svg-aam-1.0]]]</li>
     </ul>
     <section id="intro_aapi">
       <h3>Accessibility APIs</h3>


### PR DESCRIPTION
- update link from accName 1.1 to 1.2
- update ARIA link from 1.1 to ED
- alphabetize AAM spec listing
- remove redundant core aam link
- match core aam in listing a11y apis
- provide abbr for API
- closes #248


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/520.html" title="Last updated on Feb 6, 2024, 3:51 PM UTC (407f48e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/520/5f34309...407f48e.html" title="Last updated on Feb 6, 2024, 3:51 PM UTC (407f48e)">Diff</a>