### PR TITLE
feat: add IA2 and ATK mappings for text edit maxlength

### DIFF
--- a/index.html
+++ b/index.html
@@ -12282,7 +12282,9 @@
     <tr>
       <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
       <td>
-        <div class="general">Not mapped</div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `max-edit-chars: &lt;value&gt;`
+        </div>
       </td>
     </tr>
     <tr>

--- a/index.html
+++ b/index.html
@@ -12269,7 +12269,7 @@
       <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
       <td>
         <div class="objattrs">
-          <span class="type">Object attributes:</span> `max-edit-chars: &lt;value&gt;`
+          <span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`
         </div>
       </td>
     </tr>
@@ -12283,7 +12283,7 @@
       <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
       <td>
         <div class="objattrs">
-          <span class="type">Object attributes:</span> `max-edit-chars: &lt;value&gt;`
+          <span class="type">Object attributes:</span> `maxlength: &lt;value&gt;`
         </div>
       </td>
     </tr>

--- a/index.html
+++ b/index.html
@@ -12268,7 +12268,9 @@
     <tr>
       <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
       <td>
-        <div class="general">Not mapped</div>
+        <div class="objattrs">
+          <span class="type">Object attributes:</span> `max-edit-chars: &lt;value&gt;`
+        </div>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Part of the initial work for https://github.com/w3c/aria/issues/1119

Splitting out each API into a separate PR for ease of review and discussion. I've combined IA2 and ATK here since they generally seem to have the same approach re: Object Attributes, and existing object attributes look like they have the same keys across both APIs


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/smhigley/html-aam/pull/522.html" title="Last updated on Dec 13, 2023, 11:11 PM UTC (208726b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/522/ab38b66...smhigley:208726b.html" title="Last updated on Dec 13, 2023, 11:11 PM UTC (208726b)">Diff</a>