### PR TITLE
follow on to 526

### DIFF
--- a/index.html
+++ b/index.html
@@ -16842,7 +16842,7 @@
     <section class="appendix informative" id="acknowledgements">
       <h3>Acknowledgments</h3>
       <p>The following people contributed to the development of this document.</p>
-      <section class="section" id="ack_group"> <!-- left in place to ensure deep links to ID remain functional -->
+      <div class="section" id="ack_group"> <!-- left in place to ensure deep links to ID remain functional -->
         <ul id="gh-contributors"></ul>
     			<!-- list of contributors will appear here,
 					 along with link to their GitHub profiles -->
@@ -16851,7 +16851,7 @@
           Add listing of individuals who have providing meaningful
           contributions through commenting that have impacted the specification.
         -->
-      </section>
+      </div>
       <div data-include="https://rawgit.com/w3c/aria/master/common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </section>


### PR DESCRIPTION
follow on to merged #526

since the heading was removed, this is throwing a respec warning.  changing the section to a div to get rid of this warning


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/528.html" title="Last updated on Feb 6, 2024, 4:09 PM UTC (b8dd3d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/528/4ea505a...b8dd3d8.html" title="Last updated on Feb 6, 2024, 4:09 PM UTC (b8dd3d8)">Diff</a>