### PR TITLE
Addition: Name from heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -16436,6 +16436,26 @@
         </ol>
       </section>
       <section>
+        <h4>`dialog` Element Accessible Name Computation</h4>
+        <ol>
+          <li>
+            If the `dialog` element has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an 
+            <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the 
+            <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in 
+            <a class="accname">Accessible Name and Description: Computation and API Mappings</a>.
+          </li>
+          <li>
+            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `dialog` element has a 
+            <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</a> that is a heading element (`h1`-`h6`), then use the subtree of the first such element
+            as defined in <a data-cite="accname-1.2/#comp_name_from_heading">accname: Name from Heading</a>.
+          </li>
+          <li>
+            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then:, if the `dialog` element has a `title` attribute, then use that attribute.
+          </li>
+          <li>Otherwise, there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</li>
+        </ol>
+      </section>
+      <section>
         <h4>`summary` Element Accessible Name Computation</h4>
         <ol>
           <li>
@@ -16449,6 +16469,26 @@
           <li>
             If there is a `summary` element as a direct child of the `details` element, but none of the above yield a usable text string, there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
           </li>
+        </ol>
+      </section>
+      <section>
+        <h4>`article` Element Accessible Name Computation</h4>
+        <ol>
+          <li>
+            If the `article` element has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an 
+            <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the 
+            <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in 
+            <a class="accname">Accessible Name and Description: Computation and API Mappings</a>.
+          </li>
+          <li>
+            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `article` element has a 
+            <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</a> that is a heading element (`h1`-`h6`), then use the subtree of the first such element
+            as defined in <a data-cite="accname-1.2/#comp_name_from_heading">accname: Name from Heading</a>.
+          </li>
+          <li>
+            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then:, if the `article` element has a `title` attribute, then use that attribute.
+          </li>
+          <li>Otherwise, there is no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.</li>
         </ol>
       </section>
       <section>
@@ -16547,7 +16587,7 @@
         <p class="note">The document referenced by the `src` of the `iframe` element gets its name from that document's `title` element, like any other document. If there is no `title` provided, there is no accessible name.</p>
       </section>
       <section>
-        <h4>Section and Grouping Element Accessible Name Computation</h4>
+        <h4>Other Section and Grouping Element Accessible Name Computation</h4>
         <ol>
           <li>
             If the element  has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.

--- a/index.html
+++ b/index.html
@@ -16401,7 +16401,7 @@
             If the `fieldset` element has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
           </li>
           <li>
-            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `fieldset` element has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> that is a <code>legend</code> element, then use the subtree of the first such element.
+            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `fieldset` element has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> that is a <code>legend</code> element, then use the accessible name of the first such element.
           </li>
           <li>
             If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then:, if the `fieldset` element has a `title` attribute, then use that attribute.
@@ -16530,7 +16530,7 @@
             If the `table` element has an <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> or an <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attribute the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is to be calculated using the algorithm defined in <a href="" class="accname">Accessible Name and Description: Computation and API Mappings</a>.
           </li>
           <li>
-            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `table` element has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> that is a <code>caption</code> element, then use the subtree of the first such element.
+            If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `table` element has a <a href="https://dom.spec.whatwg.org/#concept-tree-child">child</a> that is a <code>caption</code> element, then use the accessible name of the first such element.
           </li>
           <li>
             If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `table` element has a `title` attribute, then use that attribute.

--- a/index.html
+++ b/index.html
@@ -16446,7 +16446,7 @@
           </li>
           <li>
             If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `dialog` element has a 
-            <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</a> that is a heading element (`h1`-`h6`), then use the subtree of the first such element
+            <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</a> that is a heading element (`h1`-`h6`), then use the accessible name of the first such element
             as defined in <a data-cite="accname-1.2/#comp_name_from_heading">accname: Name from Heading</a>.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -16482,7 +16482,7 @@
           </li>
           <li>
             If the <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is still empty, then: if the `article` element has a 
-            <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</a> that is a heading element (`h1`-`h6`), then use the subtree of the first such element
+            <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">descendant</a> that is a heading element (`h1`-`h6`), then use the accessible name of the first such element
             as defined in <a data-cite="accname-1.2/#comp_name_from_heading">accname: Name from Heading</a>.
           </li>
           <li>


### PR DESCRIPTION
closes #457

Related to the following:
- https://github.com/w3c/aria/pull/1860
- https://github.com/w3c/accname/pull/229 (this needs to be merged so the new links to 'accName: name from heading' will work

- [ ] TODO: add changelog entry when ready to merge


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/529.html" title="Last updated on Feb 8, 2024, 5:25 PM UTC (8131f4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/529/e58672f...8131f4b.html" title="Last updated on Feb 8, 2024, 5:25 PM UTC (8131f4b)">Diff</a>