### PR TITLE
Clarify hidden elements do not return name

### DIFF
--- a/index.html
+++ b/index.html
@@ -1377,7 +1377,10 @@
     <tr>
       <th>Comments</th>
       <td>
-        If a descendant of a `table`, the first instance of a `caption` element will provide the `table` its accessible name.
+        <p class=note>
+          If a `caption` element is hidden from the accessibility tree, then it will not provide an accessible name
+          to its parent `table` element.
+        </p>
       </td>
     </tr>
   </tbody>
@@ -2296,7 +2299,7 @@
           <span class="type">Role:</span> Use WAI-ARIA mapping
         </div>
         <div class="relations">
-          <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
+          <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with first instance of child <a href="#el-legend">`legend`</a> element
         </div>
       </td>
     </tr>
@@ -2315,7 +2318,7 @@
           <span class="type">Role:</span> Use WAI-ARIA mapping
         </div>
         <div class="relations">
-          <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with child <a href="#el-legend">`legend`</a> element
+          <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with first instance of child <a href="#el-legend">`legend`</a> element
         </div>
       </td>
     </tr>
@@ -2339,6 +2342,10 @@
     <tr>
       <th>Comments</th>
       <td>
+        <p class=note>
+          If a `legend` element is hidden from the accessibility tree, then it will not provide an accessible name
+          to its parent `fieldset` element.
+        </p>
       </td>
     </tr>
   </tbody>
@@ -4972,6 +4979,10 @@
     <tr>
       <th>Comments</th>
       <td>
+        <p class=note>
+          If a `label` element is hidden from the accessibility tree, then it will not provide an accessible name
+          to the labelable element is is associated with.
+        </p>
       </td>
     </tr>
   </tbody>
@@ -7366,25 +7377,34 @@
     <tr>
       <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
       <td>
-        Use WAI-ARIA mapping
+        <div class="role">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span> `IA2_RELATION_LABELLED_BY` with first instance of child <a href="#el-caption">`caption`</a> element
+        </div>
       </td>
     </tr>
     <tr>
       <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
       <td>
-        Use WAI-ARIA mapping
+        <div class="role">Use WAI-ARIA mapping</div>
       </td>
     </tr>
     <tr>
       <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
       <td>
-        Use WAI-ARIA mapping
+        <div class="role">Use WAI-ARIA mapping</div>
+        <div class="relations">
+          <span class="type">Relations:</span> `ATK_RELATION_LABELLED_BY` with first instance of child <a href="#el-caption">`caption`</a> element
+        </div>
       </td>
     </tr>
     <tr>
       <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
       <td>
-        Use WAI-ARIA mapping
+        <div class="role">Use WAI-ARIA mapping</div>
+        <div class="role-namefrom">
+          <strong>AXDescription:</strong> value from child <a href="#el-caption">`caption`</a> subtree
+        </div>
       </td>
     </tr>
     <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->


### PR DESCRIPTION
closes #370

Adds comments to label, legend and caption elements to indicate that if they are hidden, then they will not return a name for their associated elements.

Note that right now this means that 
```
<label for=d hidden>foo</label>
<input id=d title=bar>
```
has _no name_.  The label is still referenced, but because it is hidden it returns an empty name in Safari and Chromium browsers.  Firefox correctly returns "bar" as the name of the input.

I think this can probably be made more clear in the naming steps, and I can make some wpts for this... i'm just not sure exactly where to put them now without potentially overlapping or ballooning out some of the existing tests.  probably worth talking about that when we triage this.

The PR also includes some consistency cleanup for legend/caption.  

## Implementation

* WPT tests:
* Implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/533.html" title="Last updated on Mar 7, 2024, 1:28 PM UTC (45695fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/533/e644368...45695fb.html" title="Last updated on Mar 7, 2024, 1:28 PM UTC (45695fb)">Diff</a>