### PR TITLE
Specify AXAPI behaviour for `low`, `high`, and `optimum` meter attributes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11709,7 +11709,7 @@
     <tr>
       <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
       <td>
-        <div class="general">Not mapped</div>
+        <div class="general">Expose "optimal value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;high&gt;. Expose "suboptial value" if &lt;value&gt; is less than &lt;high&gt; and greater than or equal to &lt;low&gt;.</div>
       </td>
     </tr>
     <tr>
@@ -12739,7 +12739,7 @@
     <tr>
       <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
       <td>
-        <div class="general">Not mapped</div>
+        <div class="general">Expose "suboptial value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;low&gt; and less than &lt;high&gt;. If &lt;value&gt; is less than &lt;low&gt;, expose "critical value".</div>
       </td>
     </tr>
     <tr>
@@ -13995,7 +13995,7 @@
     <tr>
       <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
       <td>
-        <div class="general">Not mapped</div>
+        <div class="general">Expose "optimal value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;optimum&gt;.</div>
       </td>
     </tr>
     <tr>

--- a/index.html
+++ b/index.html
@@ -11709,7 +11709,7 @@
     <tr>
       <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
       <td>
-        <div class="general">Expose "optimal value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;high&gt;. Expose "suboptial value" if &lt;value&gt; is less than &lt;high&gt; and greater than or equal to &lt;low&gt;.</div>
+        <div class="general">Expose "optimal value" via `AXValueDescription` if &lt;value&gt; is greater than or equal to &lt;high&gt;. Expose "suboptimal value" if &lt;value&gt; is less than &lt;high&gt; and greater than or equal to &lt;low&gt;.</div>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Closes #536

Specification based on Safari behaviour/attributes exposed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MReschenberg/html-aam/pull/538.html" title="Last updated on Mar 20, 2024, 12:45 PM UTC (fcaaf19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/538/e644368...MReschenberg:fcaaf19.html" title="Last updated on Mar 20, 2024, 12:45 PM UTC (fcaaf19)">Diff</a>