### PR TITLE
add obsolete dir element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1980,6 +1980,58 @@
     </tr>
   </tbody>
 </table>
+<h4 id="el-dir">`dir`</h4>
+<table aria-labelledby="el-dir">
+  <tbody>
+    <tr>
+      <th>HTML Specification</th>
+      <td>
+        <a data-cite="HTML">`dir`</a>
+      </td>
+    </tr>
+    <tr>
+      <th>[[wai-aria-1.2]]</th>
+      <td>
+        <a class="core-mapping" href="#role-map-list">`list`</a> role
+      </td>
+    </tr>
+    <tr>
+      <th><a data-cite="core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+      <td class="role-computed"><div class="general">Use WAI-ARIA mapping</div></td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx">MSAA</a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <tr>
+      <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+      <td>
+        <div class="general">Use WAI-ARIA mapping</div>
+      </td>
+    </tr>
+    <!-- <th><a href="#accessible-name-and-description-computation">Naming Algorithm</a></th> -->
+    <tr>
+      <th>Comments</th>
+      <td>
+        The `dir` element is marked as obsolete in HTML, and is not to be used by authors. 
+      </td>
+    </tr>
+  </tbody>
+</table>
 <h4 id=el-div>`div`</h4>
 <table aria-labelledby=el-div>
   <tbody>


### PR DESCRIPTION
the dir element is semantically equivalent to the UL element, and thus it should also map to role=list.

As browsers have recently updated the rendering of this element to have visual consistency with the UL element / across browsers, then too, the mappings should update to match what is spec'd in HTML.

related to https://github.com/w3c/html-aam/issues/486 (does not fully close the issue)

related to https://github.com/whatwg/html/issues/9296

<!--- IF EDITORIAL or CHORE, delete this template -->

Describe Change Here!

## Implementation

* WPT tests: https://github.com/web-platform-tests/wpt/pull/45553
* Implementations (link to issue or when done, link to commit):
   * WebKit:
   * Gecko:
   * Blink:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/539.html" title="Last updated on Apr 4, 2024, 5:29 PM UTC (d240951)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/539/e644368...d240951.html" title="Last updated on Apr 4, 2024, 5:29 PM UTC (d240951)">Diff</a>