### PR TITLE
Clarify li element role mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -5104,7 +5104,7 @@
     <tr>
       <th>Comments</th>
       <td>
-        If `li` element is not a child of <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
+        If `li` element is not an accessibility child of an <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
         list element is no longer exposed with a `list` role, then expose the `li` element with a `generic` role.
       </td>
     </tr>

--- a/index.html
+++ b/index.html
@@ -5104,7 +5104,7 @@
     <tr>
       <th>Comments</th>
       <td>
-        If `li` element is not an accessibility child of an <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
+        If `li` element is not an [=accessibility child=] of an <a data-cite="html">`ol`</a> , <a data-cite="html">`menu`</a> or <a data-cite="html">`ul`</a>, or if the containing
         list element is no longer exposed with a `list` role, then expose the `li` element with a `generic` role.
       </td>
     </tr>


### PR DESCRIPTION
The intent of this text change is to clarify that a list item that is still a child of a list, but has intervening generic elements should still be exposed as a listitem.

e.g.,

```
<li>with no list ancestor = generic</li>

<ul>
  <div> <!-- invalid html, but SHOULD be ignored since generic  -->
    <li> since this has 'accessibility parent' of list, it should remain exposed as a list item </li>
  </div>
</ul>
```

related to https://github.com/w3c/aria/issues/2137


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/540.html" title="Last updated on Apr 18, 2024, 11:27 PM UTC (9cb316a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/540/f7e96ed...9cb316a.html" title="Last updated on Apr 18, 2024, 11:27 PM UTC (9cb316a)">Diff</a>