### PR TITLE
Add missing space for img role "wai-aria" mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -3216,7 +3216,7 @@
       <th>[[wai-aria-1.2]]</th>
       <td>
         <a class="core-mapping" href="#role-map-image">`image`</a>
-        or  <a class="core-mapping" href="#role-map-img">`img`</a>role
+        or  <a class="core-mapping" href="#role-map-img">`img`</a> role
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Fixes a small typo (missing space) for the `img` mapping section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/pull/542.html" title="Last updated on Apr 8, 2024, 2:26 PM UTC (6cf4bbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aam/542/e644368...6cf4bbb.html" title="Last updated on Apr 8, 2024, 2:26 PM UTC (6cf4bbb)">Diff</a>