### PR TITLE
Add `class` and `id` mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -9215,25 +9215,25 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx"><abbr title="Microsoft Active Accessibility">MSAA</abbr></a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>class</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>UIA_ClassNamePropertyId</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>class</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>AXDOMClassList</code></div>
               </td>
             </tr>
             <tr>
@@ -11412,25 +11412,25 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
                 <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx"><abbr title="Microsoft Active Accessibility">MSAA</abbr></a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
               </th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>id</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>UIA_AutomationIdPropertyId</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="objattrs"><span class="type">Object attributes:</span> <code>id</code></div>
               </td>
             </tr>
             <tr>
               <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
               <td>
-                <div class="general">Not mapped</div>
+                <div class="property"><span class="type">Property:</span> <code>AXDOMIdentifier</code></div>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes https://github.com/w3c/html-aam/issues/553

@aleventhal provided mappings in https://github.com/w3c/html-aam/issues/553. I verified they match up with Chromium’s mappings:

**`id`**
- `kHtmlId` maps to `id` in [ax_platform_node_base.cc;l=1506-1509](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_base.cc;l=1506-1509?q=kHtmlId&ss=chromium%2Fchromium%2Fsrc:ui%2Faccessibility%2Fplatform%2F)
- `kHtmlId` maps to `UIA_AutomationIdPropertyId` in [ax_platform_node_win.cc;l=5254-5264](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_win.cc;l=5254-5264?q=UIA_AutomationIdPropertyId&start=11) (via [`GetAuthorUniqueId()`](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_delegate.cc;l=583-587;drc=5203366d4cf174b9331ee33563e0520f10b60828))
- `kHtmlId` maps to `AXDOMIdentifier` in [ax_platform_node_cocoa.mm;l=1594-1601](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_cocoa.mm;l=1594-1601?q=AXDOMIdentifier)

**`class`**
- `kClassName` maps to `class` in [ax_platform_node_base.cc;l=1492-1497](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_base.cc;l=1492-1497?q=kClassName&ss=chromium%2Fchromium%2Fsrc:ui%2Faccessibility%2Fplatform%2F)
- `kClassName` maps to `UIA_ClassNamePropertyId` in [ax_platform_node_win.cc;l=5265-5269](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_win.cc;l=5265-5269?q=UIA_ClassNamePropertyId)
- `kClassName` maps to `AXDOMClassList` in [ax_platform_node_cocoa.mm;l=1577-1592](https://source.chromium.org/chromium/chromium/src/+/main:ui/accessibility/platform/ax_platform_node_cocoa.mm;l=1577-1592?q=AXDOMClassList)

**Reviewers:** Please also check the formatting. I’ve attempted to match existing styles, but those are inconsistent, e.g. “Object attributes” is bold in [datetime](https://w3c.github.io/html-aam/#att-datetime-time) (but not in [draggable](https://w3c.github.io/html-aam/#att-draggable)); it uses `<code>` in [src](https://w3c.github.io/html-aam/#att-src-media) (but not in [abbr](https://w3c.github.io/html-aam/#el-abbr)).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 8, 2024, 3:56 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: http://localhost:8082/uploads/lYGTdy/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2024-08-08
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aam%23559.)._
</details>
