### PR TITLE
fix: Update ATK URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,7 +540,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -590,7 +590,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -643,7 +643,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_STATIC</code></div>
                 <div class="objattrs">
@@ -698,7 +698,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -748,7 +748,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -798,7 +798,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -847,7 +847,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -894,7 +894,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -947,7 +947,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1007,7 +1007,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role: </span> <code>ATK_ROLE_AUDIO</code></div>
               </td>
@@ -1064,7 +1064,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1114,7 +1114,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1164,7 +1164,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1214,7 +1214,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1264,7 +1264,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1314,7 +1314,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1364,7 +1364,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1414,7 +1414,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1464,7 +1464,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1518,7 +1518,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_CANVAS</code></div>
               </td>
@@ -1577,7 +1577,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div class="relations">
@@ -1635,7 +1635,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. Styles used are mapped into text attributes on its text container.</div>
               </td>
@@ -1687,7 +1687,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1737,7 +1737,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1790,7 +1790,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -1840,7 +1840,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1894,7 +1894,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1947,7 +1947,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -1997,7 +1997,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2050,7 +2050,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div class="ctrltype">
@@ -2103,7 +2103,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2153,7 +2153,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2203,7 +2203,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2257,7 +2257,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_DESCRIPTION_LIST</code></div>
               </td>
@@ -2312,7 +2312,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2362,7 +2362,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2413,7 +2413,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_EMBEDDED</code></div>
               </td>
@@ -2464,7 +2464,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div class="relations"><span class="type">Relations:</span> <code>ATK_RELATION_LABELLED_BY</code> with child <a href="#el-legend"><code>legend</code></a> element</div>
@@ -2520,7 +2520,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_CAPTION</code></div>
                 <div class="relations">
@@ -2580,7 +2580,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div class="name"><span class="type">Name:</span> related <a href="#el-figcaption"><code>figcaption</code></a> content</div>
@@ -2630,7 +2630,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2682,7 +2682,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_FOOTER</code></div>
               </td>
@@ -2732,7 +2732,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div>If a <code>form</code> has no <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a>:</div>
@@ -2784,7 +2784,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2837,7 +2837,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2887,7 +2887,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -2935,7 +2935,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -2987,7 +2987,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_HEADER</code></div>
               </td>
@@ -3037,7 +3037,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3090,7 +3090,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3142,7 +3142,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3192,7 +3192,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3242,7 +3242,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_INTERNAL_FRAME</code></div>
               </td>
@@ -3297,7 +3297,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3355,7 +3355,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3406,7 +3406,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3461,7 +3461,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3520,7 +3520,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">If implemented as a button, use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping for <a class="core-mapping" href="https://w3c.github.io/core-aam/#role-map-button"><code>button</code></a>.</div>
                 <div class="general">If implemented as a textbox, use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping for <a class="core-mapping" href="https://w3c.github.io/core-aam/#role-map-textbox"><code>textbox</code></a>.</div>
@@ -3588,7 +3588,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role: </span> <code>ATK_ROLE_CALENDAR</code></div>
               </td>
@@ -3642,7 +3642,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_CALENDAR</code></div>
               </td>
@@ -3698,7 +3698,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3756,7 +3756,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_STATIC</code></div>
                 <div class="children">
@@ -3813,7 +3813,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -3864,7 +3864,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -3915,7 +3915,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_DATE_EDITOR</code></div>
               </td>
@@ -3979,7 +3979,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">If implemented as a spin button, use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping for <a class="core-mapping" href="https://w3c.github.io/core-aam/#role-map-spinbutton"><code>spinbutton</code></a>.</div>
                 <div class="general">If implemented as a text input, use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping for <a class="core-mapping" href="https://w3c.github.io/core-aam/#role-map-textbox"><code>textbox</code></a>.</div>
@@ -4035,7 +4035,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_PASSWORD_TEXT</code></div>
                 <div class="states"><span class="type">States:</span> <code>ATK_STATE_SINGLE_LINE</code>; <code>ATK_STATE_READ_ONLY</code> if readonly, otherwise <code>ATK_STATE_EDITABLE</code></div>
@@ -4096,7 +4096,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4147,7 +4147,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4198,7 +4198,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4250,7 +4250,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4303,7 +4303,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4359,7 +4359,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4413,7 +4413,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4474,7 +4474,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4529,7 +4529,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role">
                   <p>
@@ -4591,7 +4591,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4643,7 +4643,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_CALENDAR</code></div>
               </td>
@@ -4695,7 +4695,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4746,7 +4746,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. Mapped into "font-family:monospace" text attribute on its text container.</div>
               </td>
@@ -4814,7 +4814,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_LABEL</code></div>
                 <div class="relations">
@@ -4877,7 +4877,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_LABEL</code></div>
                 <div class="relations">
@@ -4937,7 +4937,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -4990,7 +4990,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5040,7 +5040,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5091,7 +5091,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped if used as an image map, otherwise:</div>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_STATIC</code></div>
@@ -5146,7 +5146,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5192,7 +5192,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>See comments</td>
             </tr>
             <tr>
@@ -5238,7 +5238,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5296,7 +5296,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5346,7 +5346,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5396,7 +5396,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5446,7 +5446,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5501,7 +5501,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Depends on format of data file. If contains a plugin then</div>
                 <div class="role">
@@ -5553,7 +5553,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5603,7 +5603,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5657,7 +5657,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5708,7 +5708,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div class="relations"><span class="type">Relations:</span> <code>ATK_RELATION_LABELLED_BY</code> with associated <code>label</code> element</div>
@@ -5763,7 +5763,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5813,7 +5813,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5863,7 +5863,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -5913,7 +5913,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -5968,7 +5968,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6018,7 +6018,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6071,7 +6071,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. No child elements are exposed if <a href="#el-ruby"><code>ruby</code></a> is supported by the browser.</div>
               </td>
@@ -6122,7 +6122,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object.</div>
               </td>
@@ -6175,7 +6175,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_STATIC</code></div>
               </td>
@@ -6227,7 +6227,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6277,7 +6277,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6327,7 +6327,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6377,7 +6377,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6430,7 +6430,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6484,7 +6484,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6538,7 +6538,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6588,7 +6588,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6638,7 +6638,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6688,7 +6688,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6738,7 +6738,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6788,7 +6788,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6838,7 +6838,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -6893,7 +6893,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -6957,7 +6957,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ROLE_TOGGLE_BUTTON</code></div>
                 <div class="relations"><span class="type">Relations:</span> <code>ATK_RELATION_DETAILS</code></div>
@@ -7013,7 +7013,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7059,7 +7059,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>See comments</td>
             </tr>
             <tr>
@@ -7101,7 +7101,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
@@ -7143,7 +7143,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
@@ -7190,7 +7190,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7241,7 +7241,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7291,7 +7291,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -7341,7 +7341,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7391,7 +7391,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7445,7 +7445,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7503,7 +7503,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7554,7 +7554,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7605,7 +7605,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7655,7 +7655,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7705,7 +7705,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7755,7 +7755,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -7805,7 +7805,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7855,7 +7855,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -7905,7 +7905,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -7955,7 +7955,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -8005,7 +8005,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">No accessible object. Styles used are mapped to text attributes on its text container.</div>
               </td>
@@ -8067,7 +8067,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="role"><span class="type">Role:</span> <code>ATK_ROLE_VIDEO</code></div>
               </td>
@@ -8124,7 +8124,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">A line break if added is exposed via Text interface on its text container</div>
               </td>
@@ -8200,7 +8200,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs">
                   <span class="type">Object attributes:</span>
@@ -8252,7 +8252,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8303,7 +8303,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8358,7 +8358,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general"><code>atk_action_get_keybinding</code></div>
               </td>
@@ -8407,7 +8407,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8458,7 +8458,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8509,7 +8509,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8565,7 +8565,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Used for <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a>, exposed via <code>atk_object_get_name</code></div>
               </td>
@@ -8614,7 +8614,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8665,7 +8665,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8716,7 +8716,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8771,7 +8771,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states">
                   <span class="type">States:</span>
@@ -8829,7 +8829,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states"><span class="type">States:</span> <code>ATK_STATE_SUPPORTS_AUTOCOMPLETION</code></div>
               </td>
@@ -8878,7 +8878,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8929,7 +8929,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -8981,7 +8981,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9032,7 +9032,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9077,7 +9077,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Property: <code>Toggle.ToggleState: On (1)</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -9123,7 +9123,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Property: <code>Toggle.ToggleState: Off (0)</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -9176,7 +9176,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9225,7 +9225,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9276,7 +9276,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9327,7 +9327,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9378,7 +9378,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -9429,7 +9429,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9498,7 +9498,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <p>
                   If the element is in the editable state, the following mappings apply to the element and every nested accessible object with the exception of those which have been specified in the
@@ -9561,7 +9561,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9610,7 +9610,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Defines an accessible object's dimensions, exposed via <code>atk_component_get_position</code> and <code>atk_component_get_size</code></div>
               </td>
@@ -9663,7 +9663,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9714,7 +9714,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9765,7 +9765,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs"><span class="type">Object attributes:</span> <code>datetime: &lt;value&gt;</code></div>
               </td>
@@ -9814,7 +9814,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs"><span class="type">Object attributes:</span> <code>datetime: &lt;value&gt;</code></div>
               </td>
@@ -9863,7 +9863,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9914,7 +9914,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -9965,7 +9965,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10016,7 +10016,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as "writing-mode" text attribute on the text container.</div>
               </td>
@@ -10067,7 +10067,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as "writing-mode" text attribute on the text container.</div>
               </td>
@@ -10118,7 +10118,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10172,7 +10172,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -10223,7 +10223,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -10271,7 +10271,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -10318,7 +10318,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10369,7 +10369,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs"><span class="objattrs">Object attributes:</span> draggable:true</div>
               </td>
@@ -10420,7 +10420,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10471,7 +10471,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10526,7 +10526,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10586,7 +10586,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">Used for <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a></div>
                 <div class="relations">
@@ -10645,7 +10645,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="relations">
                   <span class="type">Relations: </span>
@@ -10703,7 +10703,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10755,7 +10755,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10807,7 +10807,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10859,7 +10859,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10911,7 +10911,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -10960,7 +10960,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11012,7 +11012,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Links the cell to its row and <a href="https://html.spec.whatwg.org/multipage/tables.html#column-header">column header</a> cells (note, only one row and one column header cells can be exposed because of <abbr title="application programming interface">API</abbr>
@@ -11068,7 +11068,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Defines an accessible object's height (<code>atk_component_get_size</code>)</div>
               </td>
@@ -11118,7 +11118,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
@@ -11161,7 +11161,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td><code>RangeValue.Maximum</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11216,7 +11216,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Creates a link accessible object. For details, refer to
@@ -11268,7 +11268,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11320,7 +11320,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11371,7 +11371,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11422,7 +11422,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11467,7 +11467,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>See comments</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>See comments</td>
             </tr>
             <tr>
@@ -11516,7 +11516,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
@@ -11563,7 +11563,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11614,7 +11614,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11665,7 +11665,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11716,7 +11716,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11767,7 +11767,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11818,7 +11818,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -11863,7 +11863,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -11912,7 +11912,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">Associates the <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a></div>
               </td>
@@ -11964,7 +11964,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="textattrs">Exposed as "language" text attribute on the text container</div>
               </td>
@@ -12013,7 +12013,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="relations"><code>ATK_RELATION_CONTROLLER_FOR</code> point to the <code>datalist</code> element referred to by the IDREF value of the <code>list</code> attribute.</div>
               </td>
@@ -12065,7 +12065,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12114,7 +12114,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12163,7 +12163,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td><code>RangeValue.Maximum</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as <code>atk_value_get_maximum_value</code> if the element implements the <code>AtkValue</code> interface</div>
               </td>
@@ -12211,7 +12211,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td><code>RangeValue.Maximum</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as <code>atk_value_get_maximum_value</code> if the element implements the <code>AtkValue</code> interface</div>
               </td>
@@ -12259,7 +12259,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12312,7 +12312,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12363,7 +12363,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12412,7 +12412,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td><code>RangeValue.Minimum</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as <code>atk_value_get_minimum_value</code> if the element implements the <code>AtkValue</code> interface</div>
               </td>
@@ -12459,7 +12459,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td><code>RangeValue.Minimum</code></td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as <code>atk_value_get_minimum_value</code> if the element implements the <code>AtkValue</code> interface</div>
               </td>
@@ -12515,7 +12515,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states">
                   <span class="type">States:</span>
@@ -12572,7 +12572,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12623,7 +12623,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -12675,7 +12675,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12729,7 +12729,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12780,7 +12780,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12832,7 +12832,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12883,7 +12883,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12934,7 +12934,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -12985,7 +12985,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13036,7 +13036,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13087,7 +13087,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13138,7 +13138,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13185,7 +13185,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="states">
                   <span class="type">States: </span>
@@ -13240,7 +13240,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
@@ -13293,7 +13293,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13343,7 +13343,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</td>
             </tr>
             <tr>
@@ -13390,7 +13390,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13442,7 +13442,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -13498,7 +13498,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13554,7 +13554,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <p><span class="type">Relations:</span> <code>RELATION_DETAILS_FOR</code> points to invoking element. <a href="#att-popover-comments">See Comments</a>.</p>
                 <div class="objattrs">
@@ -13633,7 +13633,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
                 <div class="general"><span class="type">Object attributes:</span> <code>details-roles:popover</code></div>
@@ -13698,7 +13698,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13749,7 +13749,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13800,7 +13800,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13852,7 +13852,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -13906,7 +13906,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -13958,7 +13958,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14010,7 +14010,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -14068,7 +14068,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Reverses the numerical or alphabetical order of the child list item markers.</div>
               </td>
@@ -14117,7 +14117,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14169,7 +14169,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -14220,7 +14220,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14272,7 +14272,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -14323,7 +14323,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -14374,7 +14374,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14429,7 +14429,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped for <code>input</code> elements.</div>
                 <div class="general">For <code>select</code> element use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping.</div>
@@ -14485,7 +14485,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14537,7 +14537,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14588,7 +14588,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14638,7 +14638,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed via <code>atk_table_get_column_extent_at</code></div>
               </td>
@@ -14689,7 +14689,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -14747,7 +14747,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="objattrs">
                   <span class="type">Object attributes:</span>
@@ -14799,7 +14799,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14850,7 +14850,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14902,7 +14902,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -14953,7 +14953,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Changes the first number of the child list item accessible objects to match the <code>start</code> attribute's value.</div>
               </td>
@@ -15002,7 +15002,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>If the <code>input</code> is in the <a href="#el-input-range"><code>Range</code></a> state, set both <code>RangeValue.SmallChange</code> and <code>RangeValue.LargeChange</code> to the value of <code>step</code>.</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as <code>atk_value_get_minimum_increment</code> if the element implements the <code>AtkValue</code> interface.</div>
               </td>
@@ -15051,7 +15051,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15102,7 +15102,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -15156,7 +15156,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15207,7 +15207,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15258,7 +15258,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15312,7 +15312,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Use <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> mapping</div>
               </td>
@@ -15369,7 +15369,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">Associates the <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a></div>
               </td>
@@ -15412,7 +15412,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <td>Not mapped</td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>Not mapped</td>
             </tr>
             <tr>
@@ -15457,7 +15457,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15508,7 +15508,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15560,7 +15560,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15609,7 +15609,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general"><a href="#el-input-submit"><code>submit</code></a> type may be a default button in the form.</div>
               </td>
@@ -15662,7 +15662,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15715,7 +15715,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Defines the accessible role, states and other properties, refer to type="<a href="#el-input-text"><code>text</code></a>", type="<a href="#el-input-password"><code>password</code></a>", type="<a href="#el-input-button"><code>button</code></a>", etc
@@ -15774,7 +15774,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">
                   Defines the list item marker, which has no <a class="termref informative" data-type="dfn" href="https://www.w3.org/TR/wai-aria/#dfn-accessible-object">accessible object</a>, but is exposed as content in the accessible text of the associated list item.
@@ -15838,7 +15838,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Responsible for image map creation.</div>
               </td>
@@ -15890,7 +15890,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15941,7 +15941,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>
@@ -15994,7 +15994,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="name">
                   Associates the accessible value for entry type input elements and <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a> for button type input elements
@@ -16048,7 +16048,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as first text node of <code>li</code>'s accessible object.</div>
               </td>
@@ -16103,7 +16103,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Exposed as <code>atk_value_get_current_value</code></div>
               </td>
@@ -16158,7 +16158,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Defines an accessible object's width (<code>atk_component_get_size</code>)</div>
               </td>
@@ -16209,7 +16209,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               </td>
             </tr>
             <tr>
-              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <th><a href="https://docs.gtk.org/atk/">ATK</a></th>
               <td>
                 <div class="general">Not mapped</div>
               </td>


### PR DESCRIPTION
https://gnome.pages.gitlab.gnome.org/atk/ (the URL currently referenced throughout [html-aam](https://w3c.github.io/html-aam)) 404s, even after logging in to the GNOME GitLab instance[^1].

https://docs.gtk.org/atk/ (this PR’s replacement URL) seems to be the new location. [GTK’s “API Docs” page](https://www.gtk.org/docs/apis/) links to this URL.

[^1]: That said, [GNOME’s “Technologies” page](https://www.gnome.org/technologies/) still links to this URL. 🤷


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 8, 2024, 4:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: http://localhost:8082/uploads/HLlmfD/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2024-08-08
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aam%23560.)._
</details>
