### PR TITLE
Add selectedoption element

### DIFF
--- a/index.html
+++ b/index.html
@@ -6550,6 +6550,56 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
             </tr>
           </tbody>
         </table>
+        </section><section id="selectedoption"><div class="header-wrapper"><h4 id="el-selectedoption"><bdi class="secno">3.5.TODO </bdi><code>selectedoption</code></h4><a class="self-link" href="#el-selectedoption" aria-label="Permalink for Section 3.5.TODO"></a></div>
+        <table aria-labelledby="el-selectedoption">
+          <tbody>
+            <tr>
+              <th><abbr title="HyperText Markup Language">HTML</abbr> Specification</th>
+              <td>
+                <a data-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-selectedoption-element"><code>selectedoption</code></a>
+              </td>
+            </tr>
+            <tr>
+              <th>[<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">wai-aria-1.2</a></cite>]</th>
+              <td>No corresponding role</td>
+            </tr>
+            <tr>
+              <th><a href="https://www.w3.org/TR/core-aam-1.2/#roleMappingComputedRole">Computed Role</a></th>
+              <td class="role-computed"><div class="general">Not mapped</div></td>
+            </tr>
+            <tr>
+              <th>
+                <a href="https://msdn.microsoft.com/en-us/library/dd373608%28v=VS.85%29.aspx"><abbr title="Microsoft Active Accessibility">MSAA</abbr></a> + <a href="http://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/">IAccessible2</a>
+              </th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://msdn.microsoft.com/en-us/library/ms726297%28v=VS.85%29.aspx">UIA</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://gnome.pages.gitlab.gnome.org/atk/">ATK</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            <tr>
+              <th><a href="https://developer.apple.com/reference/appkit/nsaccessibility">AX</a></th>
+              <td>
+                <div class="general">Not mapped</div>
+              </td>
+            </tr>
+            
+            <tr>
+              <th>Comments</th>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
         </section><section id="slot"><div class="header-wrapper"><h4 id="el-slot"><bdi class="secno">3.5.116 </bdi><code>slot</code></h4><a class="self-link" href="#el-slot" aria-label="Permalink for Section 3.5.116"></a></div>
         <table aria-labelledby="el-slot">
           <tbody>


### PR DESCRIPTION
Closes #????

<!--- IF EDITORIAL or CHORE, delete this template -->

The `<selectedoption>` element is part of the [customizable select feature](https://github.com/whatwg/html/issues/9799) and is being added to HTML [here](https://github.com/whatwg/html/pull/10633).

## Implementation

* WPT tests: https://github.com/web-platform-tests/wpt/pull/45096
* Implementations (link to issue or when done, link to commit):
   * WebKit: TODO
   * Gecko: TODO
   * Blink: https://chromium.googlesource.com/chromium/src/+/18b5eac27b14b409503aa8047cf9358082a0e0df


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 27, 2024, 5:00 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: http://localhost:8082/uploads/tdr5I9/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2024-09-27
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aam%23566.)._
</details>
